### PR TITLE
Fix(workflows): Add --repo flag to gh release upload

### DIFF
--- a/.github/workflows/build-whisper-cpp.yml
+++ b/.github/workflows/build-whisper-cpp.yml
@@ -311,4 +311,4 @@ jobs:
           shasum -a 256 "${ZIP_ASSET}" > "${ZIP_ASSET}.sha256"
 
           # Upload assets
-          gh release upload ${{ needs.create-release.outputs.release_tag }} "${ZIP_ASSET}" "${ZIP_ASSET}.sha256" --clobber
+          gh release upload ${{ needs.create-release.outputs.release_tag }} "${ZIP_ASSET}" "${ZIP_ASSET}.sha256" --clobber --repo ${{ github.repository }}


### PR DESCRIPTION
This fixes the failing Windows builds by explicitly providing the repository to the `gh release upload` command. This is necessary to avoid an error where the GitHub CLI on Windows runners has trouble inferring the repository context.