### PR TITLE
Fix(workflows): Use relative paths for assets in gh release upload

### DIFF
--- a/.github/workflows/build-whisper-cpp.yml
+++ b/.github/workflows/build-whisper-cpp.yml
@@ -311,4 +311,4 @@ jobs:
           shasum -a 256 "${ZIP_ASSET}" > "${ZIP_ASSET}.sha256"
 
           # Upload assets
-          gh release upload ${{ needs.create-release.outputs.release_tag }} "${ZIP_ASSET}" "${ZIP_ASSET}.sha256" --clobber --repo ${{ github.repository }}
+          gh release upload ${{ needs.create-release.outputs.release_tag }} "./${ZIP_ASSET}" "./${ZIP_ASSET}.sha256" --clobber --repo ${{ github.repository }}


### PR DESCRIPTION
This fixes the failing Windows builds by using explicit relative paths for the assets being uploaded to the GitHub release. This is necessary to avoid a path interpretation error with the `gh` CLI on Windows runners.