### PR TITLE
Fix(workflows): Finalize ffmpeg and whisper build workflows

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -79,7 +79,6 @@ jobs:
               mingw-w64-x86_64-pkg-config
               mingw-w64-x86_64-zlib
               mingw-w64-x86_64-libiconv
-              zip
             configure_opts: >-
               --target-os=win64
               --disable-asm
@@ -102,7 +101,6 @@ jobs:
               mingw-w64-clang-aarch64-pkg-config
               mingw-w64-clang-aarch64-zlib
               mingw-w64-clang-aarch64-libiconv
-              zip
             configure_opts: >-
               --target-os=win64
               --arch=aarch64
@@ -380,7 +378,27 @@ jobs:
               }
             }
 
-      - name: Upload assets
+      - name: Upload assets (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $ReleaseDir = "${{ github.workspace }}/release_assets/${{ matrix.folder }}"
+          $ZipAsset = "ffmpeg-${{ matrix.folder }}.zip"
+          $ZipPath = Join-Path -Path $ReleaseDir -ChildPath $ZipAsset
+
+          Compress-Archive -Path "$ReleaseDir/*" -DestinationPath $ZipPath -Force
+
+          $ChecksumPath = "$($ZipPath).sha256"
+          $hash = (Get-FileHash $ZipPath -Algorithm SHA256).Hash.ToLower()
+          Set-Content -Path $ChecksumPath -Value "$hash  $ZipAsset"
+
+          gh release upload ${{ env.RELEASE_TAG }} $ZipPath $ChecksumPath --clobber
+
+      - name: Upload assets (macOS/Linux)
+        if: runner.os != 'Windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
This commit includes the final fixes for both the `build-ffmpeg.yml` and `build-whisper-cpp.yml` workflows.

**`build-ffmpeg.yml`:**
*   Switches the macOS build to dynamic linking to produce `.dylib` files.
*   Updates the asset preparation step to correctly package the `ffmpeg` binary and its `.dylib` files for macOS.
*   Refactors the upload step to create a zip archive of all release assets for each platform.
*   Fixes the Windows upload by using PowerShell (`pwsh`) and `Compress-Archive` instead of `zip`, resolving the "command not found" error.

**`build-whisper-cpp.yml`:**
*   Ensures Windows executables are fully self-contained by statically linking all SDL2 dependencies.
*   Fixes the Windows upload error by using PowerShell (`pwsh`) for the upload step.
*   Restores the release asset uploads for macOS and Linux.

These changes should resolve all reported issues and create a stable and correct build and release process for both workflows across all platforms.