### PR TITLE
Fix(workflows): Build dynamic FFmpeg for all platforms

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -273,7 +273,7 @@ jobs:
 
       - name: Configure & build FFmpeg (Windows)
         if: matrix.type == 'build' && runner.os == 'Windows'
-        shell: msys2 {0}
+        shell: bash
         run: |
           echo "Configuring and building FFmpeg for ${{ matrix.folder }} on ${{ matrix.os }}"
           CPU_COUNT=$(nproc)


### PR DESCRIPTION
This commit updates the `build-ffmpeg.yml` workflow to produce dynamically linked ffmpeg builds for all platforms (Windows, macOS, and Linux) and ensures the resulting shared libraries are included in the release assets.

The key changes are:
- The ffmpeg configure flags for all platforms are changed to `--enable-shared` and `--disable-static` to produce shared libraries (`.dll`, `.so`, `.dylib`).
- To fix the `lib.exe: command not found` error on Windows, the build step is switched to a standard `bash` shell and the `./configure` command is prefixed with `DLLTOOL=dlltool` to explicitly specify the toolchain utilities.
- The asset preparation step is updated to collect the `ffmpeg` binary and the generated shared libraries for all platforms.
- The upload step for Windows now correctly uses PowerShell to handle zipping the assets.