### PR TITLE
Fix(workflows): Build dynamic FFmpeg for all platforms

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -91,6 +91,7 @@ jobs:
               --enable-iconv
               --disable-libmp3lame
               --cross-prefix=x86_64-w64-mingw32-
+              --arch=x86_64
 
           - os: windows-latest
             folder: windows-arm64
@@ -274,7 +275,7 @@ jobs:
 
       - name: Configure & build FFmpeg (Windows)
         if: matrix.type == 'build' && runner.os == 'Windows'
-        shell: bash
+        shell: msys2 {0}
         run: |
           echo "Configuring and building FFmpeg for ${{ matrix.folder }} on ${{ matrix.os }}"
           CPU_COUNT=$(nproc)
@@ -291,7 +292,7 @@ jobs:
           )
 
           echo "Running configure with matrix opts: ${{ matrix.configure_opts }}"
-          if ! DLLTOOL=dlltool ./configure "${BASE_CONFIGURE_FLAGS[@]}" ${{ matrix.configure_opts }}; then
+          if ! env DLLTOOL=dlltool ./configure "${BASE_CONFIGURE_FLAGS[@]}" ${{ matrix.configure_opts }}; then
             echo "Configure failed. Dumping config.log"
             cat ffbuild/config.log
             exit 1


### PR DESCRIPTION
This commit updates the `build-ffmpeg.yml` workflow to produce dynamically linked ffmpeg builds for all platforms (Windows, macOS, and Linux) and ensures the resulting shared libraries are included in the release assets.

The key changes are:
- The ffmpeg configure flags for all platforms are changed to `--enable-shared` and `--disable-static` to produce shared libraries (`.dll`, `.so`, `.dylib`).
- The Windows build configurations are corrected to ensure the correct toolchain is used, fixing the `lib.exe: command not found` and `iconv not found` errors.
- The asset preparation step is updated to collect the `ffmpeg` binary and the generated shared libraries for all platforms.
- The upload step for Windows now correctly uses PowerShell to handle zipping the assets.