### PR TITLE
Fix(build): Explicitly set C compiler for FFmpeg Windows x86_64 build

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -92,6 +92,7 @@ jobs:
               --disable-libmp3lame
               --cross-prefix=x86_64-w64-mingw32-
               --arch=x86_64
+              --cc=x86_64-w64-mingw32-gcc
 
           - os: windows-latest
             folder: windows-arm64


### PR DESCRIPTION
The Windows x86_64 build for FFmpeg was consistently failing with a `lib.exe: command not found` error.

This was caused by FFmpeg's `./configure` script incorrectly auto-detecting the MSVC toolchain (specifically `cl.exe`) which is present in the default PATH of the GitHub Actions `windows-latest` runner, even within the MSYS2 environment. This resulted in a Makefile being generated that expected MSVC tools like `lib.exe` instead of the intended MinGW tools.

This commit resolves the issue by explicitly setting the C compiler for the `windows-x86_64` build using the `--cc=x86_64-w64-mingw32-gcc` flag in the `configure_opts`. This prevents the incorrect auto-detection and ensures the build process uses the correct MinGW toolchain, aligning it with the successful configuration of the `windows-arm64` job which also explicitly sets its compiler.