### PR TITLE
Fix(build): Simplify FFmpeg Windows x86_64 build configuration

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -90,9 +90,6 @@ jobs:
               --enable-zlib
               --enable-iconv
               --disable-libmp3lame
-              --cross-prefix=x86_64-w64-mingw32-
-              --arch=x86_64
-              --cc=x86_64-w64-mingw32-gcc
 
           - os: windows-latest
             folder: windows-arm64


### PR DESCRIPTION
The `windows-x86_64` FFmpeg build was failing with a `lib.exe: command not found` error. This was caused by incorrectly forcing the build into a cross-compilation mode by using `--arch` and `--cross-prefix` flags. This confused the `configure` script, which then incorrectly detected the MSVC toolchain from the runner's PATH.

This commit fixes the issue by removing the `--arch`, `--cross-prefix`, and explicit `--cc` flags.

This change is based on the successful configuration of the `update-ffmpeg.yml` workflow, which treats the MINGW64 environment provided by the `msys2/setup-msys2` action as a native build environment. By removing the unnecessary flags, we allow the `configure` script to correctly detect the native MINGW64 toolchain, which resolves the build failure.