### PR TITLE
Chore: Add diagnostic step to dump config.log

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -295,6 +295,9 @@ jobs:
             cat ffbuild/config.log
             exit 1
           fi
+
+          echo "Dumping config.log for inspection..."
+          cat ffbuild/config.log
           
           make -j${CPU_COUNT} DLLTOOL=dlltool
           make install DLLTOOL=dlltool


### PR DESCRIPTION
The build is failing at the `make` step, which indicates the `configure` script is generating an incorrect Makefile. To understand why `configure` is making the wrong decisions about the toolchain, we need to inspect its log file.

This commit adds a diagnostic step to the workflow to always print the contents of `ffbuild/config.log` after the `configure` script runs. This will provide the necessary data to accurately diagnose and fix the root cause of the persistent build failures on Windows.