### PR TITLE
Fix(build): Add diffutils to MSYS2 environment for FFmpeg build

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -79,6 +79,7 @@ jobs:
               mingw-w64-x86_64-pkg-config
               mingw-w64-x86_64-zlib
               mingw-w64-x86_64-libiconv
+              diffutils
             configure_opts: >-
               --target-os=win64
               --disable-asm
@@ -296,8 +297,6 @@ jobs:
             exit 1
           fi
 
-          echo "Dumping config.log for inspection..."
-          cat ffbuild/config.log
           
           make -j${CPU_COUNT} DLLTOOL=dlltool
           make install DLLTOOL=dlltool


### PR DESCRIPTION
The `windows-x86_64` FFmpeg build was failing with a `lib.exe: command not found` error. Analysis of the `config.log` from a failed run revealed that the root cause was a missing `cmp` command, which is part of the `diffutils` package.

The FFmpeg `configure` script uses `cmp` for various environment and toolchain checks. Without it, the script fails silently and makes incorrect assumptions, leading to the generation of a broken `Makefile` that attempts to use the MSVC toolchain (`lib.exe`) instead of the MinGW toolchain (`dlltool`).

This commit fixes the issue by adding `diffutils` to the list of packages installed in the `msys2/setup-msys2` step for the `windows-x86_64` job. This ensures that the `cmp` command is available, allowing the `configure` script to correctly detect the MinGW environment and generate a valid Makefile.

The diagnostic step to print the `config.log` has also been removed as it is no longer necessary.