### PR TITLE
chore: Fix FFmpeg windows-x86_64 build

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -82,6 +82,8 @@ jobs:
               diffutils
             configure_opts: >-
               --target-os=win64
+              --arch=x86_64
+              --cross-prefix=x86_64-w64-mingw32-
               --disable-asm
               --disable-gpl
               --disable-nonfree


### PR DESCRIPTION
The build was failing due to an incorrect toolchain selection. The configure script was attempting to use the MSVC linker (lib.exe) instead of the MinGW linker.

This change explicitly sets the architecture and cross-compilation prefix in the configure options for the windows-x86_64 job, forcing the use of the correct MinGW toolchain.