### PR TITLE
fix(ci): Correct toolchain and archiver for Windows builds

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -85,6 +85,7 @@ jobs:
               --target-os=win64
               --arch=x86_64
               --cross-prefix=x86_64-w64-mingw32-
+              --ar=x86_64-w64-mingw32-ar
               --disable-asm
               --disable-gpl
               --disable-nonfree
@@ -100,7 +101,7 @@ jobs:
             type: build
             install_deps: >-
               make
-              mingw-w64-clang-x86_64-toolchain
+              mingw-w64-clang-aarch64-toolchain
               mingw-w64-clang-x86_64-lld
               mingw-w64-clang-aarch64-pkg-config
               mingw-w64-clang-aarch64-zlib


### PR DESCRIPTION
This commit applies two critical fixes to the FFmpeg build workflow for Windows:

1.  **For `windows-x86_64`:** The build was failing because it was trying to use the MSVC linker (`lib.exe`). This is now fixed by explicitly telling the `configure` script which archiver to use via the `--ar=x86_64-w64-mingw32-ar` flag.

2.  **For `windows-arm64`:** The build was failing with `clang: command not found` because it was installing the `x86_64` Clang toolchain instead of the `aarch64` one. This has been corrected by changing the package to `mingw-w64-clang-aarch64-toolchain`.

These changes ensure the correct tools are used for each respective architecture, resolving the build failures.