### PR TITLE
fix(ci): Final fix for Windows FFmpeg builds

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -102,7 +102,6 @@ jobs:
             type: build
             install_deps: >-
               make
-              # Install the x86_64 -> aarch64 cross-compiler toolchain
               mingw-w64-x86_64-clang-aarch64-toolchain
               mingw-w64-x86_64-clang-aarch64-pkg-config
               mingw-w64-x86_64-clang-aarch64-zlib
@@ -281,6 +280,8 @@ jobs:
       - name: Configure & build FFmpeg (Windows)
         if: matrix.type == 'build' && runner.os == 'Windows'
         shell: msys2 {0}
+        env:
+          DLLTOOL: x86_64-w64-mingw32-dlltool
         run: |
           echo "Configuring and building FFmpeg for ${{ matrix.folder }} on ${{ matrix.os }}"
           CPU_COUNT=$(nproc)
@@ -297,14 +298,14 @@ jobs:
           )
 
           echo "Running configure with matrix opts: ${{ matrix.configure_opts }}"
-          if ! env DLLTOOL=x86_64-w64-mingw32-dlltool ./configure "${BASE_CONFIGURE_FLAGS[@]}" ${{ matrix.configure_opts }}; then
+          if ! ./configure "${BASE_CONFIGURE_FLAGS[@]}" ${{ matrix.configure_opts }}; then
             echo "Configure failed. Dumping config.log"
             cat ffbuild/config.log
             exit 1
           fi
           
-          make -j${CPU_COUNT} DLLTOOL=x86_64-w64-mingw32-dlltool
-          make install DLLTOOL=x86_64-w64-mingw32-dlltool
+          make -j${CPU_COUNT}
+          make install
           cd ..
 
       - name: Prepare assets for release


### PR DESCRIPTION
This commit applies the final, precise corrections to the `build-ffmpeg.yml` workflow to resolve all outstanding build failures on Windows.

For the `windows-arm64` job:
- A syntax error was corrected by removing a misplaced comment from inside the `install_deps` string, which was causing `pacman` to fail.

For the `windows-x86_64` job:
- The `DLLTOOL` environment variable is now set at the step level, which is a more robust way to ensure the entire script uses the correct MinGW tool.
- The redundant `env` prefix and `DLLTOOL=` assignments have been removed from the `configure` and `make` commands for clarity and correctness.