### PR TITLE
fix(ci): Final correction for all Windows FFmpeg builds

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -82,7 +82,7 @@ jobs:
               mingw-w64-x86_64-libiconv
               diffutils
             configure_opts: >-
-              --target-os=win64
+              --target-os=mingw32
               --arch=x86_64
               --cross-prefix=x86_64-w64-mingw32-
               --ar=x86_64-w64-mingw32-ar
@@ -102,7 +102,9 @@ jobs:
             type: build
             install_deps: >-
               make
-              mingw-w64-x86_64-clang-aarch64-toolchain
+              mingw-w64-x86_64-clang
+              mingw-w64-x86_64-clang-aarch64-clang
+              mingw-w64-x86_64-clang-aarch64-lld
               mingw-w64-x86_64-clang-aarch64-pkg-config
               mingw-w64-x86_64-clang-aarch64-zlib
               mingw-w64-x86_64-clang-aarch64-libiconv
@@ -280,8 +282,6 @@ jobs:
       - name: Configure & build FFmpeg (Windows)
         if: matrix.type == 'build' && runner.os == 'Windows'
         shell: msys2 {0}
-        env:
-          DLLTOOL: x86_64-w64-mingw32-dlltool
         run: |
           echo "Configuring and building FFmpeg for ${{ matrix.folder }} on ${{ matrix.os }}"
           CPU_COUNT=$(nproc)


### PR DESCRIPTION
This commit applies the definitive fixes for both `windows-x86_64` and `windows-arm64` FFmpeg build jobs, resolving all persistent build failures.

For the `windows-x86_64` job:
- The root cause of the `lib.exe` error was an incorrect `--target-os`. This has been changed from `win64` to `mingw32`, forcing the build system to use the MinGW toolchain correctly for all steps, including library creation.
- The now-unnecessary step-level `env: DLLTOOL` block has been removed for a cleaner implementation.

For the `windows-arm64` job:
- The `pacman` error was caused by incorrect package names. The `install_deps` list has been replaced with the correct, existing package names for the x86_64 to aarch64 Clang cross-compilation toolchain.