### PR TITLE
fix(ci): Correct indentation for Windows FFmpeg build jobs

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -85,8 +85,8 @@ jobs:
               --target-os=mingw32
               --arch=x86_64
               --cross-prefix=x86_64-w64-mingw32-
-          --ar=ar
-          --nm=nm
+              --ar=ar
+              --nm=nm
               --disable-asm
               --disable-gpl
               --disable-nonfree
@@ -102,12 +102,12 @@ jobs:
             type: build
             install_deps: >-
               make
-          mingw-w64-x86_64-aarch64-gcc
-          mingw-w64-x86_64-aarch64-pkg-config
-          mingw-w64-x86_64-aarch64-zlib
-          mingw-w64-x86_64-aarch64-libiconv
+              mingw-w64-x86_64-aarch64-gcc
+              mingw-w64-x86_64-aarch64-pkg-config
+              mingw-w64-x86_64-aarch64-zlib
+              mingw-w64-x86_64-aarch64-libiconv
             configure_opts: >-
-          --target-os=mingw32
+              --target-os=mingw32
               --arch=aarch64
               --enable-cross-compile
               --cross-prefix=aarch64-w64-mingw32-


### PR DESCRIPTION
This commit fixes a critical YAML syntax error in the `build-ffmpeg.yml` workflow. The `install_deps` and `configure_opts` keys for both the `windows-x86_64` and `windows-arm64` jobs were incorrectly indented, which would have caused the workflow to fail parsing.

This change aligns these keys correctly, ensuring the workflow file is valid. This was the final required correction.