### PR TITLE
Fixes the FFmpeg build for the windows-arm64 target by installing the…

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -53,7 +53,6 @@ jobs:
             extra_opts: "--extra-cflags=-I/usr/x86_64-w64-mingw32/include --extra-ldflags=-L/usr/x86_64-w64-mingw32/lib"
           - folder: windows-arm64
             os: ubuntu-latest
-            container: dockcross/windows-arm64
             arch: aarch64
             cross_prefix: aarch64-w64-mingw32-
             target_os: mingw32
@@ -119,7 +118,7 @@ jobs:
             sudo apt-get install -y yasm nasm pkg-config gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu zlib1g-dev:arm64
           elif [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
             sudo apt-get update -y
-            sudo apt-get install -y yasm nasm pkg-config zlib1g-dev
+            sudo apt-get install -y yasm nasm pkg-config gcc-aarch64-w64-mingw32 binutils-aarch64-w64-mingw32 zlib1g-dev
           fi
 
       - name: Install build prerequisites (macOS)


### PR DESCRIPTION
… correct cross-compilation toolchain on the Ubuntu runner.

Removes the non-functional `dockcross/windows-arm64` container and instead installs the `gcc-aarch64-w64-mingw32` and `binutils-aarch64-w64-mingw32` packages directly. This resolves the "aarch64-w64-mingw32-gcc: not found" error and allows the cross-compilation to succeed.