### PR TITLE
This commit fixes the recurring build failure for the `windows-arm64`…

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -56,7 +56,7 @@ jobs:
             container: dockcross/windows-arm64
             arch: aarch64
             target_os: mingw32
-            extra_opts: ""
+            extra_opts: "--disable-asm"
           - folder: linux-x86_64
             os: ubuntu-latest
             arch: x86_64


### PR DESCRIPTION
… FFmpeg cross-compilation target. The previous attempts failed due to assembler errors, indicating that the wrong compiler toolchain was being used inside the `dockcross/windows-arm64` container.

Instead of trying to perfectly configure the cross-compilation environment, this commit takes a more robust approach by adding the `--disable-asm` flag to the FFmpeg `./configure` command for the `windows-arm64` job.

This flag instructs FFmpeg to compile using its portable C code instead of architecture-specific assembly language, which avoids the assembler errors and allows the build to complete successfully. This is a standard workaround for complex cross-compilation issues.