### PR TITLE
This commit provides a comprehensive fix for the `windows-arm64` FFmp…

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -56,7 +56,7 @@ jobs:
             container: dockcross/windows-arm64
             arch: aarch64
             target_os: mingw32
-            extra_opts: "--disable-asm"
+            extra_opts: "--enable-cross-compile --disable-asm --cc=aarch64-w64-mingw32-clang --cxx=aarch64-w64-mingw32-clang++ --ld=aarch64-w64-mingw32-ld.lld"
           - folder: linux-x86_64
             os: ubuntu-latest
             arch: x86_64
@@ -136,11 +136,8 @@ jobs:
         run: |
           if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
             export PATH="/usr/lib/llvm-mingw/bin:$PATH"
-            export CC=aarch64-w64-mingw32-clang
-            export CXX=aarch64-w64-mingw32-clang++
             export AR=llvm-ar
             export RANLIB=llvm-ranlib
-            export LD=aarch64-w64-mingw32-ld.lld
           fi
 
           echo "Configuring and building FFmpeg for ${{ matrix.folder }} on ${{ matrix.os }}"


### PR DESCRIPTION
…eg cross-compilation job, which was failing due to a series of toolchain-related issues.

The root cause was the build process incorrectly using the host's native Linux toolchain instead of the `clang`-based cross-compiler provided by the `dockcross/windows-arm64` container. This was caused by FFmpeg's `configure` script ignoring environment variables in favor of other settings like `cross-prefix`.

This commit resolves all identified issues by taking a more direct approach:
1.  The `PATH` is updated to include the toolchain directory, and `AR`/`RANLIB` are exported to use the `llvm` versions.
2.  The `cross_prefix` is removed from the build matrix to prevent it from interfering with the compiler selection.
3.  Crucially, the C compiler (`--cc`), C++ compiler (`--cxx`), and linker (`--ld`) are passed as explicit arguments to the `configure` script via `extra_opts`. This is a more robust method that overrides any incorrect defaults.
4.  The `--enable-cross-compile` flag is added to `extra_opts` as suggested by the FFmpeg error message.
5.  The `--disable-asm` flag is also included in `extra_opts` as a robust workaround to prevent any potential assembler-related errors.