### PR TITLE
This commit provides a comprehensive fix for two separate issues in t…

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -25,17 +25,9 @@ jobs:
 
       - name: Handle Git Tag and Release
         run: |
-          # Delete remote tag
-          git push --delete origin ${{ env.RELEASE_TAG }} || echo "Tag ${{ env.RELEASE_TAG }} not found on remote."
-          # Delete local tag
-          git tag -d ${{ env.RELEASE_TAG }} || echo "Tag ${{ env.RELEASE_TAG }} not found locally."
-          # Delete release
-          gh release delete ${{ env.RELEASE_TAG }} -y || echo "Release ${{ env.RELEASE_TAG }} not found."
-          # Create new tag
-          git tag ${{ env.RELEASE_TAG }}
-          # Push new tag
-          git push origin ${{ env.RELEASE_TAG }}
-          # Create new release
+          # Delete release and associated tag, ignoring errors if it doesn't exist
+          gh release delete ${{ env.RELEASE_TAG }} --yes --cleanup-tag || echo "Release ${{ env.RELEASE_TAG }} not found, proceeding to create it."
+          # Create new release, which also creates the tag
           gh release create ${{ env.RELEASE_TAG }} --generate-notes
 
   build:


### PR DESCRIPTION
…he `build-ffmpeg.yml` workflow.

First, it resolves the persistent build failure for the `windows-arm64` FFmpeg cross-compilation job. The root cause was a complex toolchain issue where the build process was incorrectly using the host's native Linux toolchain instead of the `clang`-based cross-compiler provided by the `dockcross/windows-arm64` container. This was a result of multiple conflicting configurations. The fix involves:
1.  Correctly setting the `PATH` to the toolchain directory (`/usr/lib/llvm-mingw/bin`).
2.  Exporting `AR` and `RANLIB` to use the `llvm` versions.
3.  Removing the conflicting `cross_prefix` from the build matrix.
4.  Explicitly passing the correct `clang` compiler and `lld` linker to FFmpeg's `configure` script via `extra_opts`.
5.  Adding `--enable-cross-compile` and `--disable-asm` flags for robustness.

Second, this commit fixes a failure in the `prepare-release` job. The previous script for deleting and recreating releases and tags was complex and prone to race conditions. It has been replaced with a much simpler and more robust two-step process using the `gh` CLI's built-in functionality (`gh release delete --cleanup-tag` and `gh release create`).