### PR TITLE
fix(ci): conditionally add cross-prefix to ffmpeg configure

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -155,10 +155,16 @@ jobs:
 
           CONFIGURE_OPTS=(
             --arch=${{ matrix.arch }}
-            --cross-prefix=${{ matrix.cross_prefix }}
             --target-os=${{ matrix.target_os }}
-            ${{ matrix.extra_opts }}
           )
+
+          if [[ -n "${{ matrix.cross_prefix }}" ]]; then
+            CONFIGURE_OPTS+=(--cross-prefix=${{ matrix.cross_prefix }})
+          fi
+
+          if [[ -n "${{ matrix.extra_opts }}" ]]; then
+            CONFIGURE_OPTS+=(${{ matrix.extra_opts }})
+          fi
 
           echo "Running configure with matrix opts: ${CONFIGURE_OPTS[@]}"
           ./configure "${BASE_CONFIGURE_FLAGS[@]}" "${CONFIGURE_OPTS[@]}"


### PR DESCRIPTION
The FFmpeg build was failing for the `windows-arm64` matrix job because an empty `--cross-prefix=` argument was being passed to the `./configure` script.

This change modifies the workflow to conditionally build the configure options array, adding the `--cross-prefix` and `extra_opts` arguments only if the corresponding matrix variables are defined and non-empty. This resolves the "C compiler test failed" error.