### PR TITLE
fix(ci): correct cross-compilation setup for ffmpeg on windows-arm64

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -47,8 +47,9 @@ jobs:
             os: ubuntu-latest
             container: dockcross/windows-arm64
             arch: aarch64
+            cross_prefix: aarch64-w64-mingw32-
             target_os: mingw32
-            extra_opts: "--enable-cross-compile --disable-asm --cc=aarch64-w64-mingw32-clang --cxx=aarch64-w64-mingw32-clang++ --ld=aarch64-w64-mingw32-ld.lld"
+            extra_opts: "--enable-cross-compile --disable-asm"
           - folder: linux-x86_64
             os: ubuntu-latest
             arch: x86_64
@@ -130,6 +131,9 @@ jobs:
             export PATH="/usr/lib/llvm-mingw/bin:$PATH"
             export AR=llvm-ar
             export RANLIB=llvm-ranlib
+            export CC=aarch64-w64-mingw32-clang
+            export CXX=aarch64-w64-mingw32-clang++
+            export LD=aarch64-w64-mingw32-ld.lld
           fi
 
           echo "Configuring and building FFmpeg for ${{ matrix.folder }} on ${{ matrix.os }}"
@@ -155,16 +159,10 @@ jobs:
 
           CONFIGURE_OPTS=(
             --arch=${{ matrix.arch }}
+            --cross-prefix=${{ matrix.cross_prefix }}
             --target-os=${{ matrix.target_os }}
+            ${{ matrix.extra_opts }}
           )
-
-          if [[ -n "${{ matrix.cross_prefix }}" ]]; then
-            CONFIGURE_OPTS+=(--cross-prefix=${{ matrix.cross_prefix }})
-          fi
-
-          if [[ -n "${{ matrix.extra_opts }}" ]]; then
-            CONFIGURE_OPTS+=(${{ matrix.extra_opts }})
-          fi
 
           echo "Running configure with matrix opts: ${CONFIGURE_OPTS[@]}"
           ./configure "${BASE_CONFIGURE_FLAGS[@]}" "${CONFIGURE_OPTS[@]}"


### PR DESCRIPTION
The FFmpeg build was failing for the `windows-arm64` matrix job due to a misconfigured cross-compilation environment in the `dockcross/windows-arm64` container. The `configure` script was unable to create a test executable with the `aarch64-w64-mingw32-clang` compiler.

This change corrects the build by:
1.  Updating the matrix to define `cross_prefix: aarch64-w64-mingw32-` for the `windows-arm64` job, which is a more standard way to specify the toolchain.
2.  Removing the explicit `--cc`, `--cxx`, and `--ld` flags from `extra_opts`.
3.  Explicitly exporting the `CC`, `CXX`, and `LD` environment variables in the build step to ensure the `configure` script correctly identifies and uses the `clang`-based toolchain.