### PR TITLE
chore(ci): add improved debug step to find toolchain

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -124,11 +124,14 @@ jobs:
           rm -rf ffmpeg-src # Clean before clone
           git clone --depth 1 --branch "${{ env.FFMPEG_TAG }}" https://git.ffmpeg.org/ffmpeg.git ffmpeg-src
 
-      - name: DEBUG - List toolchain directory
+      - name: DEBUG - Find toolchain path
         if: matrix.folder == 'windows-arm64'
         run: |
-          echo "Listing contents of /usr/lib/llvm-mingw..."
-          ls -R /usr/lib/llvm-mingw
+          echo "Finding compiler path..."
+          which aarch64-w64-mingw32-clang
+          echo "---"
+          echo "System PATH..."
+          echo $PATH
 
       - name: Configure & build FFmpeg
         run: |


### PR DESCRIPTION
This step will run 'which aarch64-w64-mingw32-clang' and 'echo $PATH' to help locate the llvm-mingw toolchain inside the dockcross container. This information is needed to construct the correct --extra-cflags and --extra-ldflags for the FFmpeg configure script.