### PR TITLE
chore(ci): add find command to locate compiler

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -133,6 +133,12 @@ jobs:
           echo "System PATH..."
           echo $PATH
 
+      - name: DEBUG - Find compiler with find
+        if: matrix.folder == 'windows-arm64'
+        run: |
+          echo "Searching for compiler..."
+          find / -name aarch64-w64-mingw32-clang 2>/dev/null || echo "Compiler not found with find"
+
       - name: Configure & build FFmpeg
         run: |
           if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then


### PR DESCRIPTION
This adds a `find / -name aarch64-w64-mingw32-clang` command to the `windows-arm64` build job.

This is a diagnostic step to definitively locate the path of the cross-compiler inside the `dockcross` container. This information is required to construct the correct environment (`PATH`) and linker flags (`--extra-cflags`, `--extra-ldflags`) to fix the persistent build failure.