### PR TITLE
fix(ci): add missing linker flags for windows-arm64 build

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -48,7 +48,7 @@ jobs:
             container: dockcross/windows-arm64
             arch: aarch64
             target_os: mingw32
-            extra_opts: "--enable-cross-compile --disable-asm --cc=aarch64-w64-mingw32-clang --cxx=aarch64-w64-mingw32-clang++ --ld=aarch64-w64-mingw32-ld.lld"
+            extra_opts: "--enable-cross-compile --disable-asm --cc=aarch64-w64-mingw32-clang --cxx=aarch64-w64-mingw32-clang++ --ld=aarch64-w64-mingw32-ld.lld --extra-ldflags=-L/usr/xcc/aarch64-w64-mingw32/lib"
           - folder: linux-x86_64
             os: ubuntu-latest
             arch: x86_64
@@ -123,15 +123,6 @@ jobs:
           echo "Cloning FFmpeg source branch/tag: ${{ env.FFMPEG_TAG }} for ${{ matrix.folder }}"
           rm -rf ffmpeg-src # Clean before clone
           git clone --depth 1 --branch "${{ env.FFMPEG_TAG }}" https://git.ffmpeg.org/ffmpeg.git ffmpeg-src
-
-      - name: DEBUG - Discover compiler name
-        if: matrix.folder == 'windows-arm64'
-        run: |
-          echo "Listing executables in /usr/bin..."
-          ls -l /usr/bin
-          echo "---"
-          echo "Listing environment variables..."
-          env
 
       - name: Configure & build FFmpeg
         run: |


### PR DESCRIPTION
The FFmpeg cross-compilation for `windows-arm64` was failing because the linker was unable to find the required system libraries, resulting in a "C compiler test failed" error.

Diagnostic steps revealed that the toolchain is located in `/usr/xcc` within the `dockcross/windows-arm64` container. This path was not being searched by the linker.

This commit resolves the issue by adding an `--extra-ldflags` option to the FFmpeg configure command, explicitly pointing the linker to the correct library directory: `-L/usr/xcc/aarch64-w64-mingw32/lib`.