### PR TITLE
chore(ci): find all clang compilers in container

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -124,11 +124,11 @@ jobs:
           rm -rf ffmpeg-src # Clean before clone
           git clone --depth 1 --branch "${{ env.FFMPEG_TAG }}" https://git.ffmpeg.org/ffmpeg.git ffmpeg-src
 
-      - name: DEBUG - List /usr/xcc directory
+      - name: DEBUG - Broad search for clang
         if: matrix.folder == 'windows-arm64'
         run: |
-          echo "Listing contents of /usr/xcc..."
-          ls -lR /usr/xcc
+          echo "Searching for '*clang' in the filesystem..."
+          find / -name "*clang" 2>/dev/null || echo "No files ending in 'clang' found"
 
       - name: Configure & build FFmpeg
         run: |


### PR DESCRIPTION
Adds a diagnostic step to the `windows-arm64` build to find all files ending with "clang". This will help locate the correct cross-compiler and its toolchain directory inside the `dockcross` container, which is needed to fix the persistent build failure.