### PR TITLE
fix(ci): resolve linker error in windows-arm64 ffmpeg build

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -48,7 +48,7 @@ jobs:
             container: dockcross/windows-arm64
             arch: aarch64
             target_os: mingw32
-            extra_opts: "--enable-cross-compile --disable-asm"
+            extra_opts: "--enable-cross-compile --disable-asm --cc=aarch64-w64-mingw32-clang --cxx=aarch64-w64-mingw32-clang++ --ld=aarch64-w64-mingw32-ld.lld --extra-ldflags=-L/usr/lib"
           - folder: linux-x86_64
             os: ubuntu-latest
             arch: x86_64


### PR DESCRIPTION
The FFmpeg cross-compilation for `windows-arm64` was failing in two different ways:
1. The `configure` script would fail with a "C compiler test failed" error if the linker couldn't find system libraries.
2. If the compiler was not explicitly specified, the `make` process would fail by invoking the host's linker (`/usr/bin/ld`) instead of the correct cross-linker.

This commit provides a definitive fix by addressing both issues. It explicitly sets the full toolchain (`--cc`, `--cxx`, `--ld`) in the `extra_opts` and also provides the correct linker library path (`--extra-ldflags=-L/usr/lib`) which was discovered through a series of diagnostic steps.