### PR TITLE
fix(ci): use correct toolchain for windows-arm64 ffmpeg build

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -48,7 +48,7 @@ jobs:
             container: dockcross/windows-arm64
             arch: aarch64
             target_os: mingw32
-            extra_opts: "--enable-cross-compile --disable-asm --cc=aarch64-w64-mingw32-clang --cxx=aarch64-w64-mingw32-clang++ --ld=aarch64-w64-mingw32-ld.lld --extra-ldflags=-L/usr/lib"
+            extra_opts: "--enable-cross-compile --disable-asm --cc=aarch64-w64-mingw32-gcc --cxx=aarch64-w64-mingw32-g++ --ld=aarch64-w64-mingw32-ld --extra-ldflags=-L/usr/xcc/aarch64-w64-mingw32-cross/lib"
           - folder: linux-x86_64
             os: ubuntu-latest
             arch: x86_64


### PR DESCRIPTION
The FFmpeg cross-compilation for `windows-arm64` was failing due to an incorrect toolchain specification. The `dockcross/windows-arm64` container uses a `gcc`-based toolchain, but the workflow was attempting to use `clang`. Additionally, the linker could not find the necessary system libraries.

This commit resolves the issue by:
1.  Specifying the correct `gcc`, `g++`, and `ld` executables in the `--cc`, `--cxx`, and `--ld` flags.
2.  Adding an `--extra-ldflags` flag to point the linker to the correct library path (`-L/usr/xcc/aarch64-w64-mingw32-cross/lib`), as determined by analyzing the container's `Dockerfile`.