### PR TITLE
Fix(workflow): Add checkout step to package-release job

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -203,6 +203,9 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       RELEASE_TAG: ${{ github.event.inputs.release_tag }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The `package-release` job was failing with a 'fatal: not a git repository' error because the `gh release upload` command requires a git context to identify the repository.

This change adds a standard `actions/checkout@v4` step to the beginning of the job, which provides the necessary git context and allows the `gh` command to execute successfully.