### PR TITLE
fix(workflows): Correct typo in apt sources for linux-arm64

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -105,7 +105,7 @@ jobs:
             echo "deb [arch=amd64] http://security.ubuntu.com/ubuntu/ ${RELEASE_NAME}-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
             echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${RELEASE_NAME} main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
             echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${RELEASE_NAME}-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
-            echo "deb [arm64] http://ports.ubuntu.com/ubuntu-ports ${RELEASE_NAME}-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+            echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${RELEASE_NAME}-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
             sudo apt-get update
             sudo apt-get install -y yasm nasm pkg-config gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu zlib1g-dev:arm64
           fi


### PR DESCRIPTION
This commit fixes a typo in the `.github/workflows/build-ffmpeg.yml` file for the `linux-arm64` build job. A malformed `apt` sources list entry (`deb [arm64]`) was corrected to `deb [arch=arm64]`.

This error was introduced accidentally during a previous modification and this commit resolves it.