### PR TITLE
feat(workflows): Add retry logic for FFmpeg clone

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -133,7 +133,20 @@ jobs:
         run: |
           echo "Cloning FFmpeg source branch/tag: ${{ env.FFMPEG_TAG }} for ${{ matrix.folder }}"
           rm -rf ffmpeg-src # Clean before clone
-          git clone --depth 1 --branch "${{ env.FFMPEG_TAG }}" https://git.ffmpeg.org/ffmpeg.git ffmpeg-src
+
+          for i in {1..3}; do
+            if git clone --depth 1 --branch "${{ env.FFMPEG_TAG }}" https://git.ffmpeg.org/ffmpeg.git ffmpeg-src; then
+              echo "FFmpeg cloned successfully on attempt $i."
+              break
+            fi
+            if [[ $i -lt 3 ]]; then
+              echo "Attempt $i failed. Retrying in 5 seconds..."
+              sleep 5
+            else
+              echo "Failed to clone FFmpeg after 3 attempts."
+              exit 1
+            fi
+          done
 
       - name: Configure & build FFmpeg (non-Windows)
         if: runner.os != 'Windows'


### PR DESCRIPTION
Implements a retry mechanism in the `build-ffmpeg.yml` workflow for cloning the FFmpeg source repository. The `git clone` command will now be attempted up to three times to improve resilience against intermittent network failures.