### PR TITLE
fix(workflows): Correct toolchain for win-arm64 cross-compilation

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -123,8 +123,8 @@ jobs:
           update: true
           install: >-
             make
-            mingw-w64-clang-aarch64-toolchain
-            mingw-w64-clang-aarch64-lld
+            mingw-w64-clang-x86_64-toolchain
+            mingw-w64-clang-x86_64-lld
             mingw-w64-clang-aarch64-pkg-config
             mingw-w64-clang-aarch64-zlib
             mingw-w64-clang-aarch64-libiconv


### PR DESCRIPTION
This commit resolves an "Exec format error" in the `build-ffmpeg.yml` workflow for the `windows-arm64` job.

The previous change incorrectly installed native ARM64 compiler binaries (`mingw-w64-clang-aarch64-toolchain`) onto the x86_64 runner. This has been corrected to install the proper x86_64 toolchain (`mingw-w64-clang-x86_64-toolchain`) that is capable of cross-compiling to ARM64, aligning it with the working configuration from `update-ffmpeg.yml`.