### PR TITLE
fix(workflows): Restore target_os to win-arm64 matrix

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -69,6 +69,7 @@ jobs:
             extra_opts: "--enable-videotoolbox"
           - folder: windows-arm64
             os: windows-latest
+            target_os: win64
             msystem: CLANG64
             install_deps: >-
               make


### PR DESCRIPTION
This commit resolves a "No such file" error during the packaging step for the `windows-arm64` job in the `build-ffmpeg.yml` workflow.

The error was caused by the accidental removal of the `target_os: win64` variable from the build matrix during a previous refactoring. This variable is essential for the packaging script to correctly determine the executable's name (`ffmpeg.exe`).

Restoring this variable ensures the script can find and package the correct file, fixing the build failure.