### PR TITLE
fix(workflows): Add missing zip dependency for windows-arm64 build

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -73,6 +73,7 @@ jobs:
             msystem: CLANG64
             install_deps: >-
               make
+              zip
               mingw-w64-clang-x86_64-toolchain
               mingw-w64-clang-x86_64-lld
               mingw-w64-clang-aarch64-pkg-config


### PR DESCRIPTION
This commit resolves a `zip: command not found` error during the packaging step for the `windows-arm64` job in the `build-ffmpeg.yml` workflow.

The `zip` utility, which is explicitly used in the packaging script, was missing from the list of installed dependencies for the MSYS2 environment. This commit adds the `zip` package to the `install_deps` list in the build matrix, making the command available and allowing the workflow to complete successfully.