### PR TITLE
fix(workflows)!: Correct packaging logic for all Windows builds

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -257,7 +257,12 @@ jobs:
           ASSET_DIR="${{ github.workspace }}/assets"
           mkdir -p "${ASSET_DIR}"
           ZIP_NAME="ffmpeg-${{ matrix.folder }}.zip"
-          EXE_NAME="ffmpeg"
+
+          if [[ "${{ matrix.target_os }}" == "mingw32" ]]; then
+            EXE_NAME="ffmpeg.exe"
+          else
+            EXE_NAME="ffmpeg"
+          fi
 
           # Strip the binary
           if [[ -n "${{ matrix.cross_prefix }}" ]]; then
@@ -311,4 +316,4 @@ jobs:
 
           # Create checksum and upload
           (Get-FileHash $zipPath -Algorithm SHA256).Hash.ToLower() + "  " + $zipName | Set-Content -Path $checksumPath
-          gh release upload ${{ env.RELEASE_TAG }} $zipPath, $checksumPath --clobber
+          gh release upload ${{ env.RELEASE_TAG }} $zipPath $checksumPath --clobber


### PR DESCRIPTION
This commit provides a definitive fix for two critical, self-inflicted bugs in the `build-ffmpeg.yml` workflow's packaging steps.

1.  **Fixes `windows-x86_64` cross-compilation:** Restores the logic to correctly determine the executable name (`ffmpeg.exe`) in the non-Windows packaging step. This resolves the `No such file` error that was introduced in the previous refactoring.
2.  **Fixes `windows-arm64` native build:** Corrects a PowerShell syntax error by removing an erroneous comma from the `gh release upload` command. This resolves the `no matches found for $zipPath,` error.

This combined fix ensures that both the cross-compiled `windows-x86_64` job and the natively-compiled `windows-arm64` job are packaged and uploaded correctly.