### PR TITLE
fix(workflows): resolve git ownership error in ffmpeg win arm64 build

### DIFF
--- a/.github/workflows/build-ffmpeg-win-arm64.yml
+++ b/.github/workflows/build-ffmpeg-win-arm64.yml
@@ -108,5 +108,4 @@ jobs:
 
       - name: Upload to Release
         run: |
-          git config --global --add safe.directory ${{ github.workspace }}
-          gh release upload ${{ env.RELEASE_TAG }} ${{ github.workspace }}/release/ffmpeg-win-arm64-dynamic.zip --clobber
+          gh release upload ${{ env.RELEASE_TAG }} ${{ github.workspace }}/release/ffmpeg-win-arm64-dynamic.zip --clobber --repo ${{ github.repository }}


### PR DESCRIPTION
The 'Upload to Release' step in the `build-ffmpeg-win-arm64.yml` workflow was failing with a "dubious ownership" error from git. This occurred because the `gh` CLI was invoking git internally to determine the repository, which caused a permission issue within the workflow's container.

This commit resolves the issue by explicitly providing the repository to the `gh release upload` command using the `--repo ${{ github.repository }}` flag. This prevents the CLI from needing to call git, thus bypassing the ownership error. The unnecessary `git config --global --add safe.directory` command has also been removed.