### PR TITLE
fix(workflows): correct cd path in ffmpeg win arm64 build

### DIFF
--- a/.github/workflows/build-ffmpeg-win-arm64.yml
+++ b/.github/workflows/build-ffmpeg-win-arm64.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Package Binaries and Create Checksum
         run: |
           mkdir -p ${{ github.workspace }}/release
-          cd ${{ github.workspace }}/local/bin
+          cd ${INSTALL_PREFIX}/bin
           zip -r ${{ github.workspace }}/release/ffmpeg-win-arm64-dynamic.zip .
           cd ${{ github.workspace }}/release
           shasum -a 256 ffmpeg-win-arm64-dynamic.zip > ffmpeg-win-arm64-dynamic.zip.sha256


### PR DESCRIPTION
This commit fixes a bug in the `build-ffmpeg-win-arm64.yml` workflow where the `cd` command was failing. The command was incorrectly using a hardcoded expansion of the `${{ github.workspace }}` variable instead of the correct `${INSTALL_PREFIX}` environment variable.

The path has been reverted to `cd ${INSTALL_PREFIX}/bin` to ensure the workflow can correctly navigate to the directory containing the compiled binaries before creating the zip archive.