### PR TITLE
fix(workflows): publish release and correct artifact names

### DIFF
--- a/.github/workflows/build-ffmpeg-win-arm64.yml
+++ b/.github/workflows/build-ffmpeg-win-arm64.yml
@@ -104,10 +104,14 @@ jobs:
         run: |
           mkdir -p ${{ github.workspace }}/release
           cd ${INSTALL_PREFIX}/bin
-          zip -r ${{ github.workspace }}/release/ffmpeg-win-arm64-dynamic.zip .
+          zip -r ${{ github.workspace }}/release/ffmpeg-win-arm64.zip .
           cd ${{ github.workspace }}/release
-          shasum -a 256 ffmpeg-win-arm64-dynamic.zip > ffmpeg-win-arm64-dynamic.zip.sha256
+          shasum -a 256 ffmpeg-win-arm64.zip > ffmpeg-win-arm64.zip.sha256
 
       - name: Upload to Release
         run: |
-          gh release upload ${{ env.RELEASE_TAG }} ${{ github.workspace }}/release/ffmpeg-win-arm64-dynamic.zip ${{ github.workspace }}/release/ffmpeg-win-arm64-dynamic.zip.sha256 --clobber --repo ${{ github.repository }}
+          gh release upload ${{ env.RELEASE_TAG }} ${{ github.workspace }}/release/ffmpeg-win-arm64.zip ${{ github.workspace }}/release/ffmpeg-win-arm64.zip.sha256 --clobber --repo ${{ github.repository }}
+
+      - name: Publish Release
+        run: |
+          gh release edit ${{ env.RELEASE_TAG }} --draft=false


### PR DESCRIPTION
This commit updates the `build-ffmpeg-win-arm64.yml` workflow to address two issues:
1.  The release was being created as a draft. A new "Publish Release" step has been added that runs `gh release edit --draft=false` to ensure the release is fully published.
2.  The `-dynamic` suffix has been removed from the zip and sha256 filenames for consistency. The packaging and upload steps have been updated to use the new names.