### PR TITLE
fix(workflows): install latest gh cli to support --draft flag

### DIFF
--- a/.github/workflows/build-ffmpeg-win-arm64.yml
+++ b/.github/workflows/build-ffmpeg-win-arm64.yml
@@ -95,8 +95,11 @@ jobs:
             --disable-libmp3lame \
             --disable-asm
 
-      - name: Install GitHub CLI
+      - name: Install Latest GitHub CLI
         run: |
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-key.asc | dd of=/usr/share/keyrings/githubcli-archive-key.asc
+          chmod go+r /usr/share/keyrings/githubcli-archive-key.asc
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-key.asc] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           apt-get update
           apt-get install -y gh
 


### PR DESCRIPTION
This commit fixes a failure in the `build-ffmpeg-win-arm64.yml` workflow where the `gh release edit` command failed with an "unknown flag: --draft" error.

The root cause was that the version of the GitHub CLI installed via `apt-get` on the runner was outdated and did not support this flag. The workflow has been updated to install the latest version of `gh` by adding the official GitHub CLI repository before installation. This ensures that all modern flags and commands are available, allowing the release to be published correctly.