### PR TITLE
fix(workflows): install gnupg for gh cli installation

### DIFF
--- a/.github/workflows/build-ffmpeg-win-arm64.yml
+++ b/.github/workflows/build-ffmpeg-win-arm64.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends cmake yasm nasm pkg-config git curl zip binutils-mingw-w64-x86-64
+          apt-get install -y --no-install-recommends cmake yasm nasm pkg-config git curl zip binutils-mingw-w64-x86-64 gnupg
 
       - name: Checkout SDL2
         uses: actions/checkout@v4


### PR DESCRIPTION
This commit provides the final fix for the `build-ffmpeg-win-arm64.yml` workflow. The previous attempt to install the latest GitHub CLI failed with `gpg: not found` because the `gnupg` package, which provides the `gpg` command, was not installed in the minimal container environment.

This has been corrected by adding `gnupg` to the list of dependencies installed by `apt-get`. This ensures that `gpg` is available, allowing the official `gh` installation script to run successfully. This provides the modern version of the CLI needed for the `gh release edit --draft=false` command to work.

This commit finalizes the workflow to correctly:
- Install all necessary dependencies, including `gnupg`
- Install the latest `gh` CLI
- Build the FFmpeg binary
- Create and upload the zip and sha256 artifacts
- Publish the release successfully