### PR TITLE
Fix GitHub CLI installation in ARM64 workflow

### DIFF
--- a/.github/workflows/build-ffmpeg-win-arm64.yml
+++ b/.github/workflows/build-ffmpeg-win-arm64.yml
@@ -97,9 +97,9 @@ jobs:
 
       - name: Install Latest GitHub CLI
         run: |
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-key.asc | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-key.gpg
-          chmod go+r /usr/share/keyrings/githubcli-archive-key.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-key.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           apt-get update
           apt-get install -y gh
 


### PR DESCRIPTION
This commit fixes the failing `build-ffmpeg-win-arm64.yml` workflow. The `curl` command to download the GitHub CLI GPG key was using an outdated URL, causing a 404 error.

The command has been updated to use the latest, correct URL and method for adding the `gh` APT repository, ensuring the CLI is installed successfully.