### PR TITLE
Fix dubious ownership error in ARM64 workflow

### DIFF
--- a/.github/workflows/build-ffmpeg-win-arm64.yml
+++ b/.github/workflows/build-ffmpeg-win-arm64.yml
@@ -117,4 +117,4 @@ jobs:
 
       - name: Publish Release
         run: |
-          gh release edit ${{ env.RELEASE_TAG }} --draft=false
+          gh release edit ${{ env.RELEASE_TAG }} --draft=false --repo ${{ github.repository }}


### PR DESCRIPTION
This commit resolves a "dubious ownership" error that occurred when running `gh release edit`. The error is common in containerized GitHub Actions environments where the git repository context is not automatically trusted.

By adding the `--repo ${{ github.repository }}` flag to the `gh release edit` command, the CLI is explicitly told which repository to operate on, bypassing the need for a local git context check and resolving the error.