### PR TITLE
Fix FFmpeg build process in ARM64 workflow

### DIFF
--- a/.github/workflows/build-ffmpeg-win-arm64.yml
+++ b/.github/workflows/build-ffmpeg-win-arm64.yml
@@ -94,6 +94,8 @@ jobs:
             --disable-doc \
             --disable-libmp3lame \
             --disable-asm
+          make -j$(nproc)
+          make install
 
       - name: Install Latest GitHub CLI
         run: |


### PR DESCRIPTION
This commit resolves a critical issue where the FFmpeg binaries were not being compiled or installed, resulting in an incomplete release asset.

The `make -j$(nproc)` and `make install` commands were missing from the "Configure and Build FFmpeg" step. This has now been corrected, ensuring that FFmpeg is properly built and its binaries are available for the subsequent packaging step.