### PR TITLE
fix(workflows): resolve SDL2 build failure on Windows

### DIFF
--- a/.github/workflows/build-whisper-cpp.yml
+++ b/.github/workflows/build-whisper-cpp.yml
@@ -201,17 +201,13 @@ jobs:
           rm -rf build
           mkdir build && cd build
           cmake .. -DCMAKE_BUILD_TYPE=Release \
+                   -DCMAKE_SYSTEM_NAME=Windows \
                    -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/SDL2-install" \
                    -DSDL_STATIC=ON \
                    -DSDL_SHARED=OFF \
                    ${{ matrix.cmake_opts }}
-          if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
-            make -j$(nproc)
-            make install
-          else
-            cmake --build . --config Release
-            cmake --install . --config Release
-          fi
+          cmake --build . --config Release
+          cmake --install . --config Release
           echo "SDL2_DIR=${{ github.workspace }}/SDL2-install" >> $GITHUB_ENV
           cd ../..
 


### PR DESCRIPTION
This commit fixes a build failure in the `build-whisper-cpp.yml` workflow that occurred when building the SDL2 dependency on Windows. The issue was caused by CMake incorrectly detecting the target operating system.

The following changes were made:
- Added the `-DCMAKE_SYSTEM_NAME=Windows` flag to the SDL2 `cmake` command.
- Unified the build commands for both Windows architectures to use `cmake --build`.