### PR TITLE
fix(workflows): resolve Windows build failures and enable OpenBLAS

### DIFF
--- a/.github/workflows/build-whisper-cpp.yml
+++ b/.github/workflows/build-whisper-cpp.yml
@@ -217,17 +217,32 @@ jobs:
           echo "Building SDL2 from source for ${{ matrix.folder }}"...
           curl -sL "https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/SDL2-${SDL2_VERSION}.tar.gz" | tar xz
           cd SDL2-${SDL2_VERSION}
+          if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
+            cat <<EOF > toolchain.cmake
+            set(CMAKE_SYSTEM_NAME Windows)
+            set(CMAKE_SYSTEM_PROCESSOR ARM64)
+            set(CMAKE_C_COMPILER clang)
+            set(CMAKE_CXX_COMPILER clang++)
+            set(CMAKE_RC_COMPILER windres)
+            set(CMAKE_FIND_ROOT_PATH /clangarm64)
+            set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+            set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+            set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+            set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+            EOF
+          fi
           rm -rf build
           mkdir build && cd build
           if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
             cmake .. -DCMAKE_BUILD_TYPE=Release \
-                     -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/toolchain.cmake \
+                     -DCMAKE_TOOLCHAIN_FILE=../toolchain.cmake \
                      -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/SDL2-install" \
                      -DSDL_STATIC=ON \
                      -DSDL_SHARED=OFF \
                      ${{ matrix.cmake_opts }}
           else
             cmake .. -DCMAKE_BUILD_TYPE=Release \
+                     -DCMAKE_SYSTEM_NAME=Windows \
                      -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/SDL2-install" \
                      -DSDL_STATIC=ON \
                      -DSDL_SHARED=OFF \
@@ -258,7 +273,7 @@ jobs:
           mkdir -p "${INSTALL_PREFIX}"
           CMAKE_COMMON_FLAGS="-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DWHISPER_SDL2=ON -DWHISPER_OPENBLAS=ON -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}"
           if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
-            cmake .. ${CMAKE_COMMON_FLAGS} ${{ matrix.cmake_opts }} -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/toolchain.cmake -DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }} -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++ -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lversion -luuid -lsetupapi -lksuser -lshell32"
+            cmake .. ${CMAKE_COMMON_FLAGS} ${{ matrix.cmake_opts }} -DCMAKE_TOOLCHAIN_FILE=../../SDL2-2.30.5/toolchain.cmake -DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }} -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++ -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lversion -luuid -lsetupapi -lksuser -lshell32"
           else
             cmake .. ${CMAKE_COMMON_FLAGS} ${{ matrix.cmake_opts }} -DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }} -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++ -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lversion -luuid -lsetupapi -lksuser -lshell32"
           fi


### PR DESCRIPTION
This commit resolves several issues in the `build-whisper-cpp.yml` workflow that were causing the Windows builds to fail. It also enables OpenBLAS support for improved CPU performance.

The following changes were made:
- Switched the CMake generator for Windows builds to "Ninja" to resolve toolchain and compiler issues.
- Introduced a CMake toolchain file for the `windows-arm64` build to fix the cross-compilation "Exec format error".
- Switched to using `CMAKE_PREFIX_PATH` to ensure the SDL2 library is found.
- Ensured that the `main` and `stream` executables are built for both Windows architectures.
- Added the `-DWHISPER_OPENBLAS=ON` flag to the `cmake` command for Windows builds.
- Ensured all Windows build steps run within the `msys2 {0}` shell.
- Updated the Windows build steps to use `ninja` instead of `make`.
- Fixed pathing issues with the toolchain file.
- Re-added the `-DCMAKE_SYSTEM_NAME=Windows` flag for the x64 SDL2 build.