### PR TITLE
fix(workflows): resolve Windows build failures and enable OpenBLAS

### DIFF
--- a/.github/workflows/build-whisper-cpp.yml
+++ b/.github/workflows/build-whisper-cpp.yml
@@ -94,23 +94,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Create CMake toolchain file for Windows ARM64
-        if: matrix.folder == 'windows-arm64'
-        shell: bash
-        run: |
-          cat <<EOF > toolchain.cmake
-          set(CMAKE_SYSTEM_NAME Windows)
-          set(CMAKE_SYSTEM_PROCESSOR ARM64)
-          set(CMAKE_C_COMPILER clang)
-          set(CMAKE_CXX_COMPILER clang++)
-          set(CMAKE_RC_COMPILER windres)
-          set(CMAKE_FIND_ROOT_PATH /clangarm64)
-          set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-          set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-          set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-          set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
-          EOF
-
       - name: Install prerequisites (macOS)
         if: runner.os == 'macOS'
         run: brew install sdl2
@@ -218,18 +201,16 @@ jobs:
           curl -sL "https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/SDL2-${SDL2_VERSION}.tar.gz" | tar xz
           cd SDL2-${SDL2_VERSION}
           if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
-            cat <<EOF > toolchain.cmake
-            set(CMAKE_SYSTEM_NAME Windows)
-            set(CMAKE_SYSTEM_PROCESSOR ARM64)
-            set(CMAKE_C_COMPILER clang)
-            set(CMAKE_CXX_COMPILER clang++)
-            set(CMAKE_RC_COMPILER windres)
-            set(CMAKE_FIND_ROOT_PATH /clangarm64)
-            set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-            set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-            set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-            set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
-            EOF
+            echo "set(CMAKE_SYSTEM_NAME Windows)" > toolchain.cmake
+            echo "set(CMAKE_SYSTEM_PROCESSOR ARM64)" >> toolchain.cmake
+            echo "set(CMAKE_C_COMPILER clang)" >> toolchain.cmake
+            echo "set(CMAKE_CXX_COMPILER clang++)" >> toolchain.cmake
+            echo "set(CMAKE_RC_COMPILER windres)" >> toolchain.cmake
+            echo "set(CMAKE_FIND_ROOT_PATH /clangarm64)" >> toolchain.cmake
+            echo "set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)" >> toolchain.cmake
+            echo "set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)" >> toolchain.cmake
+            echo "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> toolchain.cmake
+            echo "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)" >> toolchain.cmake
           fi
           rm -rf build
           mkdir build && cd build


### PR DESCRIPTION
This commit resolves several issues in the `build-whisper-cpp.yml` workflow that were causing the Windows builds to fail. It also enables OpenBLAS support for improved CPU performance.

The following changes were made:
- Switched the CMake generator for Windows builds to "Ninja" to resolve toolchain and compiler issues.
- Introduced a CMake toolchain file for the `windows-arm64` build to fix the cross-compilation "Exec format error".
- Switched to using `CMAKE_PREFIX_PATH` to ensure the SDL2 library is found.
- Ensured that the `main` and `stream` executables are built for both Windows architectures.
- Added the `-DWHISPER_OPENBLAS=ON` flag to the `cmake` command for Windows builds.
- Ensured all Windows build steps run within the `msys2 {0}` shell.
- Updated the Windows build steps to use `ninja` instead of `make`.
- Fixed pathing issues with the toolchain file.
- Re-added the `-DCMAKE_SYSTEM_NAME=Windows` flag for the x64 SDL2 build.
- Fixed a `here-document` syntax error by replacing it with a series of `echo` commands.