### PR TITLE
Fix(CI): Overhaul Windows build process for whisper.cpp

### DIFF
--- a/.github/toolchains/aarch64-w64-mingw32.cmake
+++ b/.github/toolchains/aarch64-w64-mingw32.cmake
@@ -1,0 +1,22 @@
+# This file is adapted from the following source:
+# https://github.com/dvhh/ffmpeg-wos-arm64-build/blob/main/aarch64-w64-mingw32.cmake
+#
+# Use with CMAKE_TOOLCHAIN_FILE
+# See: https://cmake.org/cmake/help/book/mastering-cmake/chapter/Cross%20Compiling%20With%20CMake.html
+# See: https://bitbucket.org/multicoreware/x265_git/wiki/CrossCompile
+
+# The name of the target operating system
+set(CMAKE_SYSTEM_NAME Windows)
+
+# Which compilers to use for C and C++
+set(CMAKE_C_COMPILER   aarch64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER aarch64-w64-mingw32-g++)
+set(CMAKE_RC_COMPILER aarch64-w64-mingw32-windres)
+
+# Adjust the default behavior of the FIND_XXX() commands:
+# Search programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# Search headers and libraries in the target environment
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/.github/toolchains/x86_64-w64-mingw32.cmake
+++ b/.github/toolchains/x86_64-w64-mingw32.cmake
@@ -1,0 +1,22 @@
+# This file is adapted from the following source:
+# https://github.com/dvhh/ffmpeg-wos-arm64-build/blob/main/aarch64-w64-mingw32.cmake
+#
+# Use with CMAKE_TOOLCHAIN_FILE
+# See: https://cmake.org/cmake/help/book/mastering-cmake/chapter/Cross%20Compiling%20With%20CMake.html
+# See: https://bitbucket.org/multicoreware/x265_git/wiki/CrossCompile
+
+# The name of the target operating system
+set(CMAKE_SYSTEM_NAME Windows)
+
+# Which compilers to use for C and C++
+set(CMAKE_C_COMPILER   x86_64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+set(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
+
+# Adjust the default behavior of the FIND_XXX() commands:
+# Search programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+# Search headers and libraries in the target environment
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/.github/workflows/build-whisper-cpp.yml
+++ b/.github/workflows/build-whisper-cpp.yml
@@ -75,12 +75,14 @@ jobs:
           - os: macos-14
             folder: macos-arm64
             cmake_opts: "-DCMAKE_OSX_ARCHITECTURES=arm64"
-          - os: windows-latest
+          - os: ubuntu-latest
+            container: "mstorsjo/llvm-mingw:20241001"
             folder: windows-x86_64
-            cmake_opts: "-G \"Unix Makefiles\""
-          - os: windows-latest
+            cmake_opts: ""
+          - os: ubuntu-latest
+            container: "mstorsjo/llvm-mingw:20241001"
             folder: windows-arm64
-            cmake_opts: "-G \"Unix Makefiles\""
+            cmake_opts: ""
           - os: ubuntu-latest
             folder: linux-x86_64
             cmake_opts: ""
@@ -98,40 +100,10 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install sdl2
 
-      - name: Setup MSYS2 environment (Windows ARM64)
-        if: matrix.folder == 'windows-arm64'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: CLANGARM64
-          update: true
-          install: >-
-            make
-            cmake
-            mingw-w64-clang-aarch64-toolchain
-            mingw-w64-clang-aarch64-pkg-config
-            mingw-w64-clang-aarch64-openblas
-            mingw-w64-clang-aarch64-zlib
-            mingw-w64-clang-aarch64-libiconv
-            zip
 
-      - name: Setup MSYS2 environment (Windows x86_64)
-        if: matrix.folder == 'windows-x86_64'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: CLANG64
-          update: true
-          install: >-
-            make
-            cmake
-            mingw-w64-clang-x86_64-toolchain
-            mingw-w64-clang-x86_64-pkg-config
-            mingw-w64-clang-x86_64-openblas
-            mingw-w64-clang-x86_64-zlib
-            mingw-w64-clang-x86_64-libiconv
-            zip
 
       - name: Install prerequisites (Linux)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.container == ''
         run: |
           set -e
           if [[ "${{ matrix.folder }}" == "linux-arm64" ]]; then
@@ -190,49 +162,49 @@ jobs:
             make install
           fi
 
-      - name: Install prerequisites (Windows)
-        if: runner.os == 'Windows'
-        shell: msys2 {0}
+      - name: Build (Windows Cross-Compile)
+        if: matrix.container != ''
         run: |
           set -e
-          SDL2_VERSION="2.30.5"
-          INSTALL_PREFIX="${{ github.workspace }}/SDL2-install"
+          apt-get update && apt-get install -y cmake curl zip
+
+          # Build SDL2
+          SDL2_INSTALL_PATH="${{ github.workspace }}/SDL2-install-${{ matrix.folder }}"
+          echo "SDL2_DIR=${SDL2_INSTALL_PATH}" >> $GITHUB_ENV
           HOST_ARCH=""
           if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
             HOST_ARCH="aarch64-w64-mingw32"
           else
             HOST_ARCH="x86_64-w64-mingw32"
           fi
-
-          echo "Building SDL2 from source for ${{ matrix.folder }} using host ${HOST_ARCH}"
-
-          # Download and extract SDL2 source
+          SDL2_VERSION="2.30.5"
           curl -sL "https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/SDL2-${SDL2_VERSION}.tar.gz" | tar xz
           cd SDL2-${SDL2_VERSION}
-
-          # Explicitly set the compilers to avoid auto-detection issues
-          export CC=clang
-          export CXX=clang++
-
-          # Configure, build, and install SDL2 using Autotools
-          ./configure --host=${HOST_ARCH} --prefix=${INSTALL_PREFIX} --enable-static --disable-shared
+          ./configure --host=${HOST_ARCH} --prefix=${SDL2_INSTALL_PATH} --enable-static --disable-shared
           make -j$(nproc)
           make install
+          cd ..
 
-          # Set environment variable for whisper.cpp build
-          echo "SDL2_DIR=${INSTALL_PREFIX}" >> $GITHUB_ENV
-
-      - name: List installed SDL2 files (Debug)
-        if: runner.os == 'Windows' && matrix.folder == 'windows-arm64'
-        run: |
-          echo "Listing contents of ${{ github.workspace }}/SDL2-install:"
-          ls -R "${{ github.workspace }}/SDL2-install" || true
-
-      - name: Clone whisper.cpp
-        run: git clone --depth 1 --branch v1.6.2 https://github.com/ggml-org/whisper.cpp.git whisper.cpp
+          # Build whisper.cpp
+          git clone --depth 1 --branch v1.6.2 https://github.com/ggml-org/whisper.cpp.git whisper.cpp
+          cd whisper.cpp
+          rm -rf build
+          mkdir build && cd build
+          INSTALL_PREFIX="${{ github.workspace }}/whisper-cpp-install/${{ matrix.folder }}"
+          TOOLCHAIN_FILE="${{ github.workspace }}/.github/toolchains/${HOST_ARCH}.cmake"
+          cmake .. -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \
+                   -DCMAKE_BUILD_TYPE=Release \
+                   -DBUILD_SHARED_LIBS=OFF \
+                   -DWHISPER_SDL2=ON \
+                   -DWHISPER_OPENBLAS=ON \
+                   -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
+                   -DCMAKE_PREFIX_PATH=${SDL2_INSTALL_PATH} \
+                   -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++ -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lversion -luuid -lsetupapi -lksuser -lshell32"
+          make -j$(nproc) main stream
+          make install
 
       - name: Build whisper-cpp (macOS/Linux)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.container == ''
         run: |
           rm -rf whisper.cpp/build
           mkdir -p whisper.cpp/build
@@ -266,19 +238,6 @@ jobs:
             cmake --build . --config Release --target install
           fi
 
-      - name: Build whisper-cpp (Windows)
-        if: runner.os == 'Windows'
-        shell: msys2 {0}
-        run: |
-          rm -rf whisper.cpp/build
-          mkdir -p whisper.cpp/build
-          cd whisper.cpp/build
-          INSTALL_PREFIX="${{ github.workspace }}/whisper-cpp-install/${{ matrix.folder }}"
-          mkdir -p "${INSTALL_PREFIX}"
-          CMAKE_COMMON_FLAGS="-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DWHISPER_SDL2=ON -DWHISPER_OPENBLAS=ON -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}"
-          cmake .. ${CMAKE_COMMON_FLAGS} ${{ matrix.cmake_opts }} -DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }} -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++ -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lversion -luuid -lsetupapi -lksuser -lshell32"
-          make -j$(nproc) main stream
-          make install
 
       - name: List installed whisper-cpp files (Debug)
         run: |
@@ -291,41 +250,37 @@ jobs:
         run: |
           mkdir -p release_assets
           INSTALL_PREFIX="${{ github.workspace }}/whisper-cpp-install/${{ matrix.folder }}"
-          if [[ "${{ runner.os }}" == "Windows" ]]; then
-            cp "whisper.cpp/build/bin/main.exe" release_assets/whisper-cli.exe
-            cp "whisper.cpp/build/bin/stream.exe" release_assets/whisper-stream.exe
+          if [[ "${{ matrix.folder }}" == "windows-x86_64" || "${{ matrix.folder }}" == "windows-arm64" ]]; then
+            cp "${INSTALL_PREFIX}/bin/main.exe" release_assets/whisper-cli.exe
+            cp "${INSTALL_PREFIX}/bin/stream.exe" release_assets/whisper-stream.exe
           else
-            cp "whisper.cpp/build/bin/main" release_assets/whisper-cli
-            cp "whisper.cpp/build/bin/stream" release_assets/whisper-stream
+            cp "${INSTALL_PREFIX}/bin/main" release_assets/whisper-cli
+            cp "${INSTALL_PREFIX}/bin/stream" release_assets/whisper-stream
           fi
           echo "--- Prepared assets ---"
           ls -lh release_assets
 
-      - name: Install zip
-        if: runner.os == 'Windows'
-        run: choco install zip
-      - name: Upload assets
-        if: runner.os == 'Windows'
-        shell: pwsh
+
+      - name: Upload assets (macOS/Linux)
+        if: matrix.container == ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $ErrorActionPreference = "Stop"
-          $ZipAsset = "whisper-sidecars-${{ matrix.folder }}.zip"
+          set -ex
+          cd release_assets
 
-          Push-Location release_assets
-          Compress-Archive -Path * -DestinationPath $ZipAsset -Force
-          Pop-Location
+          # Create zip archive
+          ZIP_ASSET="whisper-sidecars-${{ matrix.folder }}.zip"
+          zip "${ZIP_ASSET}" *
 
-          $ZipPath = "release_assets/$ZipAsset"
-          $ChecksumPath = "$($ZipPath).sha256"
-          $hash = (Get-FileHash $ZipPath -Algorithm SHA256).Hash.ToLower()
-          Set-Content -Path $ChecksumPath -Value "$hash  $ZipAsset"
+          # Create checksum
+          shasum -a 256 "${ZIP_ASSET}" > "${ZIP_ASSET}.sha256"
 
-          gh release upload ${{ needs.create-release.outputs.release_tag }} $ZipPath $ChecksumPath --clobber --repo ${{ github.repository }}
+          # Upload assets
+          gh release upload ${{ needs.create-release.outputs.release_tag }} "${ZIP_ASSET}" "${ZIP_ASSET}.sha256" --clobber --repo ${{ github.repository }}
 
-      - name: Upload assets (macOS/Linux)
-        if: runner.os != 'Windows'
+      - name: Upload assets (Windows)
+        if: matrix.container != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
This commit resolves the persistent Windows build failures by completely overhauling the build strategy. The previous approach of building natively on Windows with MSYS2 was unreliable.

This new implementation, based on a working example, incorporates the following fixes:

1.  **Containerized Cross-Compilation**: The `windows-x86_64` and `windows-arm64` jobs now run on `ubuntu-latest` within the `mstorsjo/llvm-mingw` Docker container, which provides a robust cross-compilation toolchain.

2.  **Isolated Build Logic**: A new, separate build step has been added to handle the Windows cross-compilation. This isolates the new logic from the existing, working macOS and Linux builds, preventing regressions.

3.  **Reliable Dependency Build**: Within the new Windows step, the SDL2 dependency is now built using the proven `./configure --host=...` method, which works correctly in the container environment.

4.  **Toolchain Files**: New CMake toolchain files have been added to ensure the main `whisper.cpp` build is correctly configured for cross-compilation.

5.  **Isolated Asset Upload**: A separate upload step for Windows assets has been added, ensuring a clean separation of concerns.