### PR TITLE
Fix: Correct GitHub Actions workflow build errors

### DIFF
--- a/.github/workflows/build-whisper-cpp.yml
+++ b/.github/workflows/build-whisper-cpp.yml
@@ -200,26 +200,24 @@ jobs:
           cd SDL2-${SDL2_VERSION}
           rm -rf build
           mkdir build && cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release \
-                   -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/SDL2-install" \
-                   -DSDL_STATIC=ON \
-                   -DSDL_SHARED=OFF \
-                   ${{ matrix.cmake_opts }}
+
+          CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/SDL2-install -DSDL_STATIC=ON -DSDL_SHARED=OFF ${{ matrix.cmake_opts }}"
+
           if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
-            cat <<EOF > ../arm64-toolchain.cmake
-            set(CMAKE_SYSTEM_NAME Windows)
-            set(CMAKE_SYSTEM_PROCESSOR ARM64)
-            set(CMAKE_C_COMPILER clang)
-            set(CMAKE_CXX_COMPILER clang++)
-            EOF
-            cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../arm64-toolchain.cmake -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/SDL2-install" -DSDL_STATIC=ON -DSDL_SHARED=OFF ${{ matrix.cmake_opts }}
-            make -j$(nproc)
-            make install
+            TOOLCHAIN_FILE_PATH="${{ github.workspace }}/arm64-toolchain.cmake"
+            echo "set(CMAKE_SYSTEM_NAME Windows)" > "${TOOLCHAIN_FILE_PATH}"
+            echo "set(CMAKE_SYSTEM_PROCESSOR ARM64)" >> "${TOOLCHAIN_FILE_PATH}"
+            echo "set(CMAKE_C_COMPILER clang)" >> "${TOOLCHAIN_FILE_PATH}"
+            echo "set(CMAKE_CXX_COMPILER clang++)" >> "${TOOLCHAIN_FILE_PATH}"
+            CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE_PATH}"
           else
-            cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/SDL2-install" -DSDL_STATIC=ON -DSDL_SHARED=OFF ${{ matrix.cmake_opts }}
-            make -j$(nproc)
-            make install
+            CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_SYSTEM_NAME=Windows"
           fi
+
+          cmake .. ${CMAKE_ARGS}
+          make -j$(nproc)
+          make install
+
           echo "SDL2_DIR=${{ github.workspace }}/SDL2-install" >> $GITHUB_ENV
           cd ../..
 
@@ -291,7 +289,7 @@ jobs:
                      -DCMAKE_CXX_COMPILER="${{ env.TOOLCHAIN_DIR }}/bin/aarch64-none-linux-gnu-g++" \
                      -DCMAKE_PREFIX_PATH="${{ env.SDL2_DIR }}" \
                      -DCMAKE_EXE_LINKER_FLAGS="-static"
-            make -j$(nproc)
+            make -j$(nproc) main stream
             make install
           elif [[ "${{ matrix.folder }}" == "linux-x86_64" ]]; then
             cmake .. -DCMAKE_BUILD_TYPE=Release \
@@ -300,10 +298,11 @@ jobs:
                      -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
                      -DCMAKE_PREFIX_PATH="${{ env.SDL2_DIR }}" \
                      -DCMAKE_EXE_LINKER_FLAGS="-static"
-            make -j$(nproc)
+            make -j$(nproc) main stream
             make install
           else # For macOS
             cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DWHISPER_SDL2=ON -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" ${{ matrix.cmake_opts }}
+            cmake --build . --config Release --target main --target stream
             cmake --build . --config Release --target install
           fi
 
@@ -344,7 +343,7 @@ jobs:
 
 
       - name: Upload assets (macOS/Linux)
-        if: matrix.container == ''
+        if: runner.os != 'Windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -362,7 +361,7 @@ jobs:
           gh release upload ${{ needs.create-release.outputs.release_tag }} "${ZIP_ASSET}" "${ZIP_ASSET}.sha256" --clobber --repo ${{ github.repository }}
 
       - name: Upload assets (Windows)
-        if: matrix.container != ''
+        if: runner.os == 'Windows'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
This commit resolves multiple failures in the `build-whisper-cpp.yml` workflow:

- **Windows:**
  - Corrects the SDL2 build process for `windows-arm64` by creating the CMake toolchain file before configuration.
  - Replaces a failing `here-document` with `echo` commands to avoid shell syntax errors.

- **macOS/Linux:**
  - Explicitly builds the `main` and `stream` targets to prevent "No such file or directory" errors during asset preparation.

- **General:**
  - Updates asset upload conditions to use `runner.os` for more reliable platform detection.