### PR TITLE
Fix: Correct GitHub Actions workflow build errors

### DIFF
--- a/.github/workflows/build-whisper-cpp.yml
+++ b/.github/workflows/build-whisper-cpp.yml
@@ -199,23 +199,24 @@ jobs:
           curl -sL "https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/SDL2-${SDL2_VERSION}.tar.gz" | tar xz
           cd SDL2-${SDL2_VERSION}
 
-          INSTALL_PREFIX="${{ github.workspace }}/SDL2-install"
+          INSTALL_PREFIX_WIN="${{ github.workspace }}/SDL2-install"
+          INSTALL_PREFIX_UNIX="$(cygpath -u "${INSTALL_PREFIX_WIN}")"
           HOST_ARCH=""
           if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
             HOST_ARCH="--host=aarch64-w64-mingw32"
-            export CC=clang
-            export CXX=clang++
+            export CC=aarch64-w64-mingw32-clang
+            export CXX=aarch64-w64-mingw32-clang++
           fi
 
           ./configure ${HOST_ARCH} \
-            --prefix=${INSTALL_PREFIX} \
+            --prefix="${INSTALL_PREFIX_UNIX}" \
             --enable-static \
             --disable-shared
 
           make -j$(nproc)
           make install
 
-          echo "SDL2_DIR=${INSTALL_PREFIX}" >> $GITHUB_ENV
+          echo "SDL2_DIR=${INSTALL_PREFIX_WIN}" >> $GITHUB_ENV
           cd ../..
 
       - name: List installed SDL2 files (Debug)


### PR DESCRIPTION
This commit resolves multiple failures in the `build-whisper-cpp.yml` workflow:

- **Windows:**
  - Replaces the unreliable CMake build for SDL2 with a more robust Autotools (`./configure` and `make`) build.
  - Correctly configures the `windows-arm64` cross-compilation by setting the full cross-compiler names for `CC` and `CXX`.
  - Fixes a `libtool` pathing error by converting the installation prefix to a Unix-style path.

- **macOS/Linux:**
  - Corrects the path for the manual copy step to look for executables in the `bin` subdirectory of the build folder.