### PR TITLE
Fix: Correct GitHub Actions workflow build errors

### DIFF
--- a/.github/workflows/build-whisper-cpp.yml
+++ b/.github/workflows/build-whisper-cpp.yml
@@ -204,8 +204,8 @@ jobs:
           HOST_ARCH=""
           if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
             HOST_ARCH="--host=aarch64-w64-mingw32"
-            export CC=aarch64-w64-mingw32-clang
-            export CXX=aarch64-w64-mingw32-clang++
+            export CC=clang
+            export CXX=clang++
           fi
 
           ./configure ${HOST_ARCH} \
@@ -319,8 +319,9 @@ jobs:
           cd whisper.cpp/build
           INSTALL_PREFIX="${{ github.workspace }}/whisper-cpp-install/${{ matrix.folder }}"
           mkdir -p "${INSTALL_PREFIX}"
+          SDL2_DIR_UNIX="$(cygpath -u "${{ env.SDL2_DIR }}")"
           CMAKE_COMMON_FLAGS="-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DWHISPER_SDL2=ON -DWHISPER_OPENBLAS=ON -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}"
-          cmake .. ${CMAKE_COMMON_FLAGS} ${{ matrix.cmake_opts }} -DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }} -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++ -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lversion -luuid -lsetupapi -lksuser -lshell32"
+          cmake .. ${CMAKE_COMMON_FLAGS} ${{ matrix.cmake_opts }} -DCMAKE_PREFIX_PATH=${SDL2_DIR_UNIX} -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++ -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lversion -luuid -lsetupapi -lksuser -lshell32"
           cmake --build . --config Release --target main --target stream --parallel
           cmake --build . --config Release --target install
           mkdir -p "${INSTALL_PREFIX}/bin/"


### PR DESCRIPTION
This commit resolves multiple failures in the `build-whisper-cpp.yml` workflow:

- **Windows ARM64:**
  - Correctly sets the `CC` and `CXX` environment variables to `clang` and `clang++` for the Autotools build of SDL2, allowing the configure script to find the correct cross-compiler.

- **Windows x64:**
  - Fixes the `whisper.cpp` CMake build by converting the `SDL2_DIR` environment variable to a Unix-style path using `cygpath`, allowing CMake to find the SDL2 library.

- **All Platforms:**
  - Previous fixes for artifact packaging and build commands are maintained.