### PR TITLE
Fix: Correct GitHub Actions workflow build errors

### DIFF
--- a/.github/workflows/build-whisper-cpp.yml
+++ b/.github/workflows/build-whisper-cpp.yml
@@ -198,25 +198,25 @@ jobs:
           echo "Building SDL2 from source for ${{ matrix.folder }}"...
           curl -sL "https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/SDL2-${SDL2_VERSION}.tar.gz" | tar xz
           cd SDL2-${SDL2_VERSION}
+          rm -rf build
+          mkdir build && cd build
 
-          INSTALL_PREFIX_WIN="${{ github.workspace }}/SDL2-install"
-          INSTALL_PREFIX_UNIX="$(cygpath -u "${INSTALL_PREFIX_WIN}")"
-          HOST_ARCH=""
+          CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/SDL2-install -DSDL_STATIC=ON -DSDL_SHARED=OFF"
           if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
-            HOST_ARCH="--host=aarch64-w64-mingw32"
-            export CC=clang
-            export CXX=clang++
+            echo "set(CMAKE_SYSTEM_NAME Windows)" > toolchain.cmake
+            echo "set(CMAKE_SYSTEM_PROCESSOR ARM64)" >> toolchain.cmake
+            echo "set(CMAKE_C_COMPILER clang)" >> toolchain.cmake
+            echo "set(CMAKE_CXX_COMPILER clang++)" >> toolchain.cmake
+            CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=./toolchain.cmake"
+          else
+            CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_SYSTEM_NAME=Windows"
           fi
 
-          ./configure ${HOST_ARCH} \
-            --prefix="${INSTALL_PREFIX_UNIX}" \
-            --enable-static \
-            --disable-shared
+          cmake .. ${CMAKE_ARGS}
+          cmake --build . --config Release --parallel
+          cmake --build . --config Release --target install
 
-          make -j$(nproc)
-          make install
-
-          echo "SDL2_DIR=${INSTALL_PREFIX_WIN}" >> $GITHUB_ENV
+          echo "SDL2_DIR=${{ github.workspace }}/SDL2-install" >> $GITHUB_ENV
           cd ../..
 
       - name: List installed SDL2 files (Debug)
@@ -320,7 +320,7 @@ jobs:
           INSTALL_PREFIX="${{ github.workspace }}/whisper-cpp-install/${{ matrix.folder }}"
           mkdir -p "${INSTALL_PREFIX}"
           SDL2_DIR_UNIX="$(cygpath -u "${{ env.SDL2_DIR }}")"
-          CMAKE_COMMON_FLAGS="-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DWHISPER_SDL2=ON -DWHISPER_OPENBLAS=ON -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}"
+          CMAKE_COMMON_FLAGS="-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DWHISPER_SDL2=ON -DWHISPER_OPENBLAS=OFF -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}"
           cmake .. ${CMAKE_COMMON_FLAGS} ${{ matrix.cmake_opts }} -DCMAKE_PREFIX_PATH=${SDL2_DIR_UNIX} -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++ -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lversion -luuid -lsetupapi -lksuser -lshell32"
           cmake --build . --config Release --target main --target stream --parallel
           cmake --build . --config Release --target install


### PR DESCRIPTION
This commit resolves multiple failures in the `build-whisper-cpp.yml` workflow:

- **Windows ARM64:**
  - Fixes the SDL2 CMake build by creating a toolchain file in the build directory and referencing it with a relative path. This ensures the cross-compilation environment is correctly detected.

- **Windows x64:**
  - Disables OpenBLAS to prevent `cblas.h not found` errors.

- **All Windows Builds:**
  - Reverts the SDL2 build to use CMake.

- **All Platforms:**
  - Previous fixes for artifact packaging and build commands are maintained.