### PR TITLE
Fix: Correct GitHub Actions workflow build errors

### DIFF
--- a/.github/workflows/build-whisper-cpp.yml
+++ b/.github/workflows/build-whisper-cpp.yml
@@ -198,25 +198,25 @@ jobs:
           echo "Building SDL2 from source for ${{ matrix.folder }}"...
           curl -sL "https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/SDL2-${SDL2_VERSION}.tar.gz" | tar xz
           cd SDL2-${SDL2_VERSION}
-          rm -rf build
-          mkdir build && cd build
 
-          CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/SDL2-install -DSDL_STATIC=ON -DSDL_SHARED=OFF"
+          INSTALL_PREFIX_WIN="${{ github.workspace }}/SDL2-install"
+          INSTALL_PREFIX_UNIX="$(cygpath -u "${INSTALL_PREFIX_WIN}")"
+          HOST_ARCH=""
           if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
-            echo "set(CMAKE_SYSTEM_NAME Windows)" > toolchain.cmake
-            echo "set(CMAKE_SYSTEM_PROCESSOR ARM64)" >> toolchain.cmake
-            echo "set(CMAKE_C_COMPILER clang)" >> toolchain.cmake
-            echo "set(CMAKE_CXX_COMPILER clang++)" >> toolchain.cmake
-            CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=./toolchain.cmake"
-          else
-            CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_SYSTEM_NAME=Windows"
+            HOST_ARCH="--host=aarch64-w64-mingw32"
+            export CC=aarch64-w64-mingw32-clang
+            export CXX=aarch64-w64-mingw32-clang++
           fi
 
-          cmake .. ${CMAKE_ARGS}
-          cmake --build . --config Release --parallel
-          cmake --build . --config Release --target install
+          ./configure ${HOST_ARCH} \
+            --prefix="${INSTALL_PREFIX_UNIX}" \
+            --enable-static \
+            --disable-shared
 
-          echo "SDL2_DIR=${{ github.workspace }}/SDL2-install" >> $GITHUB_ENV
+          make -j$(nproc)
+          make install
+
+          echo "SDL2_DIR=${INSTALL_PREFIX_WIN}" >> $GITHUB_ENV
           cd ../..
 
       - name: List installed SDL2 files (Debug)


### PR DESCRIPTION
This commit resolves multiple failures in the `build-whisper-cpp.yml` workflow:

- **Windows ARM64:**
  - Fixes the SDL2 build by reverting to Autotools and setting the correct cross-compiler names for `CC` and `CXX`.

- **Windows x64:**
  - Disables OpenBLAS to prevent `cblas.h not found` errors.

- **All Windows Builds:**
  - Uses `cygpath` to ensure correct pathing for dependencies in the MSYS2 environment.

- **All Platforms:**
  - Previous fixes for artifact packaging and build commands are maintained.