### PR TITLE
feat(ci): refactor whisper.cpp workflow for robust builds

### DIFF
--- a/.github/toolchains/aarch64-w64-mingw32.cmake
+++ b/.github/toolchains/aarch64-w64-mingw32.cmake
@@ -1,22 +1,14 @@
-# This file is adapted from the following source:
-# https://github.com/dvhh/ffmpeg-wos-arm64-build/blob/main/aarch64-w64-mingw32.cmake
-#
-# Use with CMAKE_TOOLCHAIN_FILE
-# See: https://cmake.org/cmake/help/book/mastering-cmake/chapter/Cross%20Compiling%20With%20CMake.html
-# See: https://bitbucket.org/multicoreware/x265_git/wiki/CrossCompile
+# This is a CMake toolchain file for cross-compiling to Windows ARM64
+# It's designed to be used within the mstorsjo/llvm-mingw Docker container
 
-# The name of the target operating system
 set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR ARM64)
 
-# Which compilers to use for C and C++
-set(CMAKE_C_COMPILER   aarch64-w64-mingw32-gcc)
-set(CMAKE_CXX_COMPILER aarch64-w64-mingw32-g++)
+set(CMAKE_C_COMPILER aarch64-w64-mingw32-clang)
+set(CMAKE_CXX_COMPILER aarch64-w64-mingw32-clang++)
 set(CMAKE_RC_COMPILER aarch64-w64-mingw32-windres)
 
-# Adjust the default behavior of the FIND_XXX() commands:
-# Search programs in the host environment
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-
-# Search headers and libraries in the target environment
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/.github/toolchains/x86_64-w64-mingw32.cmake
+++ b/.github/toolchains/x86_64-w64-mingw32.cmake
@@ -1,22 +1,14 @@
-# This file is adapted from the following source:
-# https://github.com/dvhh/ffmpeg-wos-arm64-build/blob/main/aarch64-w64-mingw32.cmake
-#
-# Use with CMAKE_TOOLCHAIN_FILE
-# See: https://cmake.org/cmake/help/book/mastering-cmake/chapter/Cross%20Compiling%20With%20CMake.html
-# See: https://bitbucket.org/multicoreware/x265_git/wiki/CrossCompile
+# This is a CMake toolchain file for cross-compiling to Windows x86_64
+# It's designed to be used within the mstorsjo/llvm-mingw Docker container
 
-# The name of the target operating system
 set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
-# Which compilers to use for C and C++
-set(CMAKE_C_COMPILER   x86_64-w64-mingw32-gcc)
-set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+set(CMAKE_C_COMPILER x86_64-w64-mingw32-clang)
+set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-clang++)
 set(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
 
-# Adjust the default behavior of the FIND_XXX() commands:
-# Search programs in the host environment
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-
-# Search headers and libraries in the target environment
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/.github/workflows/build-whisper-cpp.yml
+++ b/.github/workflows/build-whisper-cpp.yml
@@ -62,6 +62,7 @@ jobs:
     name: Build & Upload Binaries
     needs: create-release
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     env:
       SDL2_DIR: "" # Initialize SDL2_DIR to avoid static analysis warnings
       TOOLCHAIN_DIR: "" # Initialize TOOLCHAIN_DIR to avoid static analysis warnings
@@ -75,11 +76,13 @@ jobs:
           - os: macos-14
             folder: macos-arm64
             cmake_opts: "-DCMAKE_OSX_ARCHITECTURES=arm64"
-          - os: windows-latest
+          - os: ubuntu-latest
             folder: windows-x86_64
+            container: mstorsjo/llvm-mingw
             cmake_opts: ""
-          - os: windows-latest
+          - os: ubuntu-latest
             folder: windows-arm64
+            container: mstorsjo/llvm-mingw
             cmake_opts: ""
           - os: ubuntu-latest
             folder: linux-x86_64
@@ -98,37 +101,6 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install sdl2
 
-      - name: Setup MSYS2 environment (Windows ARM64)
-        if: matrix.folder == 'windows-arm64'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: CLANGARM64
-          update: true
-          install: >-
-            make
-            cmake
-            mingw-w64-clang-aarch64-toolchain
-            mingw-w64-clang-aarch64-pkg-config
-            mingw-w64-clang-aarch64-openblas
-            mingw-w64-clang-aarch64-zlib
-            mingw-w64-clang-aarch64-libiconv
-            zip
-
-      - name: Setup MSYS2 environment (Windows x86_64)
-        if: matrix.folder == 'windows-x86_64'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: CLANG64
-          update: true
-          install: >-
-            make
-            cmake
-            mingw-w64-clang-x86_64-toolchain
-            mingw-w64-clang-x86_64-pkg-config
-            mingw-w64-clang-x86_64-openblas
-            mingw-w64-clang-x86_64-zlib
-            mingw-w64-clang-x86_64-libiconv
-            zip
 
       - name: Install prerequisites (Linux)
         if: runner.os == 'Linux' && matrix.container == ''
@@ -190,146 +162,74 @@ jobs:
             make install
           fi
 
-      - name: Install prerequisites (Windows)
-        if: runner.os == 'Windows'
-        shell: msys2 {0}
-        run: |
-          SDL2_VERSION="2.30.5"
-          echo "Building SDL2 from source for ${{ matrix.folder }}"...
-          curl -sL "https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/SDL2-${SDL2_VERSION}.tar.gz" | tar xz
-          cd SDL2-${SDL2_VERSION}
-          rm -rf build
-          mkdir build && cd build
-
-          if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
-            echo "set(CMAKE_SYSTEM_NAME Windows)" > toolchain.cmake
-            echo "set(CMAKE_SYSTEM_PROCESSOR ARM64)" >> toolchain.cmake
-            echo "set(CMAKE_C_COMPILER clang)" >> toolchain.cmake
-            echo "set(CMAKE_CXX_COMPILER clang++)" >> toolchain.cmake
-            cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/SDL2-install -DSDL_STATIC=ON -DSDL_SHARED=OFF -DCMAKE_TOOLCHAIN_FILE=./toolchain.cmake
-          else
-            cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/SDL2-install -DSDL_STATIC=ON -DSDL_SHARED=OFF -DCMAKE_SYSTEM_NAME=Windows
-          fi
-
-          make -j$(nproc)
-          make install
-
-          echo "SDL2_DIR=${{ github.workspace }}/SDL2-install" >> $GITHUB_ENV
-          cd ../..
-
-      - name: List installed SDL2 files (Debug)
-        if: runner.os == 'Windows' && matrix.folder == 'windows-arm64'
-        run: |
-          echo "Listing contents of ${{ github.workspace }}/SDL2-install:"
-          ls -R "${{ github.workspace }}/SDL2-install" || true
 
       - name: Clone whisper.cpp
         run: git clone --depth 1 --branch v1.6.2 https://github.com/ggml-org/whisper.cpp.git whisper.cpp
 
-      - name: Build (Windows Cross-Compile)
-        if: matrix.container != ''
+
+
+
+      - name: Build whisper.cpp
         run: |
-          set -e
-          apt-get update && apt-get install -y cmake curl zip
-
-          # Build SDL2
-          SDL2_INSTALL_PATH="${{ github.workspace }}/SDL2-install-${{ matrix.folder }}"
-          echo "SDL2_DIR=${SDL2_INSTALL_PATH}" >> $GITHUB_ENV
-          HOST_ARCH=""
-          if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
-            HOST_ARCH="aarch64-w64-mingw32"
-          else
-            HOST_ARCH="x86_64-w64-mingw32"
-          fi
-          SDL2_VERSION="2.30.5"
-          curl -sL "https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/SDL2-${SDL2_VERSION}.tar.gz" | tar xz
-          cd SDL2-${SDL2_VERSION}
-          ./configure --host=${HOST_ARCH} --prefix=${SDL2_INSTALL_PATH} --enable-static --disable-shared
-          make -j$(nproc)
-          make install
-          cd ..
-
-          # Build whisper.cpp
+          set -ex
           cd whisper.cpp
           rm -rf build
           mkdir build && cd build
           INSTALL_PREFIX="${{ github.workspace }}/whisper-cpp-install/${{ matrix.folder }}"
-          TOOLCHAIN_FILE="${{ github.workspace }}/.github/toolchains/${HOST_ARCH}.cmake"
-          cmake .. -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \
-                   -DCMAKE_BUILD_TYPE=Release \
-                   -DBUILD_SHARED_LIBS=OFF \
-                   -DWHISPER_SDL2=ON \
-                   -DWHISPER_OPENBLAS=ON \
-                   -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
-                   -DCMAKE_PREFIX_PATH=${SDL2_INSTALL_PATH} \
-                   -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++ -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lversion -luuid -lsetupapi -lksuser -lshell32"
+
+          # Base CMake options
+          CMAKE_OPTS=(
+            "-DCMAKE_BUILD_TYPE=Release"
+            "-DBUILD_SHARED_LIBS=OFF"
+            "-DWHISPER_SDL2=ON"
+            "-DWHISPER_OPENBLAS=ON"
+            "-DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}"
+          )
+
+          # Platform-specific configurations
+          if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
+            apt-get update && apt-get install -y --no-install-recommends ca-certificates curl xz-utils zip
+            SDL2_INSTALL_PATH="${{ github.workspace }}/SDL2-install"
+            ./../scripts/build-sdl2-mingw.sh aarch64-w64-mingw32 "${SDL2_INSTALL_PATH}"
+            TOOLCHAIN_FILE="${{ github.workspace }}/.github/toolchains/aarch64-w64-mingw32.cmake"
+            CMAKE_OPTS+=(
+              "-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}"
+              "-DCMAKE_PREFIX_PATH=${SDL2_INSTALL_PATH}"
+              "-DCMAKE_EXE_LINKER_FLAGS=-static -static-libgcc -static-libstdc++ -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lversion -luuid -lsetupapi -lksuser -lshell32"
+            )
+          elif [[ "${{ matrix.folder }}" == "windows-x86_64" ]]; then
+            apt-get update && apt-get install -y --no-install-recommends ca-certificates curl xz-utils zip
+            SDL2_INSTALL_PATH="${{ github.workspace }}/SDL2-install"
+            ./../scripts/build-sdl2-mingw.sh x86_64-w64-mingw32 "${SDL2_INSTALL_PATH}"
+            TOOLCHAIN_FILE="${{ github.workspace }}/.github/toolchains/x86_64-w64-mingw32.cmake"
+            CMAKE_OPTS+=(
+              "-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}"
+              "-DCMAKE_PREFIX_PATH=${SDL2_INSTALL_PATH}"
+              "-DCMAKE_EXE_LINKER_FLAGS=-static -static-libgcc -static-libstdc++ -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lversion -luuid -lsetupapi -lksuser -lshell32"
+            )
+          elif [[ "${{ matrix.folder }}" == "linux-arm64" ]]; then
+            CMAKE_OPTS+=(
+              "-DCMAKE_SYSTEM_NAME=Linux"
+              "-DCMAKE_SYSTEM_PROCESSOR=aarch64"
+              "-DCMAKE_C_COMPILER=${{ env.TOOLCHAIN_DIR }}/bin/aarch64-none-linux-gnu-gcc"
+              "-DCMAKE_CXX_COMPILER=${{ env.TOOLCHAIN_DIR }}/bin/aarch64-none-linux-gnu-g++"
+              "-DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }}"
+              "-DCMAKE_EXE_LINKER_FLAGS=-static"
+            )
+          elif [[ "${{ matrix.folder }}" == "linux-x86_64" ]]; then
+            CMAKE_OPTS+=(
+              "-DCMAKE_PREFIX_PATH=${{ env.SDL2_DIR }}"
+              "-DCMAKE_EXE_LINKER_FLAGS=-static"
+            )
+          elif [[ "${{ matrix.folder }}" == "macos-arm64" ]]; then
+            CMAKE_OPTS+=("-DCMAKE_OSX_ARCHITECTURES=arm64")
+          elif [[ "${{ matrix.folder }}" == "macos-x86_64" ]]; then
+            CMAKE_OPTS+=("-DCMAKE_OSX_ARCHITECTURES=x86_64")
+          fi
+
+          cmake .. "${CMAKE_OPTS[@]}"
           make -j$(nproc) main stream
           make install
-
-      - name: Build whisper-cpp (macOS/Linux)
-        if: runner.os != 'Windows' && matrix.container == ''
-        run: |
-          rm -rf whisper.cpp/build
-          mkdir -p whisper.cpp/build
-          cd whisper.cpp/build
-          INSTALL_PREFIX="${{ github.workspace }}/whisper-cpp-install/${{ matrix.folder }}"
-          mkdir -p "${INSTALL_PREFIX}"
-          if [[ "${{ matrix.folder }}" == "linux-arm64" ]]; then
-            cmake .. -DCMAKE_BUILD_TYPE=Release \
-                     -DBUILD_SHARED_LIBS=OFF \
-                     -DWHISPER_SDL2=ON \
-                     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-                     -DCMAKE_SYSTEM_NAME=Linux \
-                     -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
-                     -DCMAKE_C_COMPILER="${{ env.TOOLCHAIN_DIR }}/bin/aarch64-none-linux-gnu-gcc" \
-                     -DCMAKE_CXX_COMPILER="${{ env.TOOLCHAIN_DIR }}/bin/aarch64-none-linux-gnu-g++" \
-                     -DCMAKE_PREFIX_PATH="${{ env.SDL2_DIR }}" \
-                     -DCMAKE_EXE_LINKER_FLAGS="-static"
-            make -j$(nproc) main stream
-            make install
-            mkdir -p "${INSTALL_PREFIX}/bin/"
-            cp ./bin/main ./bin/stream "${INSTALL_PREFIX}/bin/"
-          elif [[ "${{ matrix.folder }}" == "linux-x86_64" ]]; then
-            cmake .. -DCMAKE_BUILD_TYPE=Release \
-                     -DBUILD_SHARED_LIBS=OFF \
-                     -DWHISPER_SDL2=ON \
-                     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-                     -DCMAKE_PREFIX_PATH="${{ env.SDL2_DIR }}" \
-                     -DCMAKE_EXE_LINKER_FLAGS="-static"
-            make -j$(nproc) main stream
-            make install
-            mkdir -p "${INSTALL_PREFIX}/bin/"
-            cp ./bin/main ./bin/stream "${INSTALL_PREFIX}/bin/"
-          else # For macOS
-            cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DWHISPER_SDL2=ON -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" ${{ matrix.cmake_opts }}
-            cmake --build . --config Release --target main --target stream
-            cmake --build . --config Release --target install
-            mkdir -p "${INSTALL_PREFIX}/bin/"
-            cp ./bin/main ./bin/stream "${INSTALL_PREFIX}/bin/"
-          fi
-
-      - name: Build whisper-cpp (Windows)
-        if: runner.os == 'Windows'
-        shell: msys2 {0}
-        run: |
-          rm -rf whisper.cpp/build
-          mkdir -p whisper.cpp/build
-          cd whisper.cpp/build
-          INSTALL_PREFIX="${{ github.workspace }}/whisper-cpp-install/${{ matrix.folder }}"
-          mkdir -p "${INSTALL_PREFIX}"
-          SDL2_DIR_UNIX="$(cygpath -u "${{ env.SDL2_DIR }}")"
-          MSYS2_PREFIX=""
-          if [[ "${{ matrix.folder }}" == "windows-arm64" ]]; then
-            MSYS2_PREFIX="/clangarm64"
-          else
-            MSYS2_PREFIX="/clang64"
-          fi
-          CMAKE_COMMON_FLAGS="-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DWHISPER_SDL2=ON -DWHISPER_OPENBLAS=ON -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}"
-          cmake .. ${CMAKE_COMMON_FLAGS} ${{ matrix.cmake_opts }} -DCMAKE_PREFIX_PATH="${SDL2_DIR_UNIX};${MSYS2_PREFIX}" -DCMAKE_EXE_LINKER_FLAGS="-static -static-libgcc -static-libstdc++ -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lversion -luuid -lsetupapi -lksuser -lshell32"
-          cmake --build . --config Release --target main --target stream --parallel
-          cmake --build . --config Release --target install
-          mkdir -p "${INSTALL_PREFIX}/bin/"
-          cp bin/main.exe bin/stream.exe "${INSTALL_PREFIX}/bin/"
 
       - name: List installed whisper-cpp files (Debug)
         run: |

--- a/whisper.cpp/scripts/build-sdl2-mingw.sh
+++ b/whisper.cpp/scripts/build-sdl2-mingw.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -ex
+
+# This script is designed to be run inside the mstorsjo/llvm-mingw container
+# It downloads and builds SDL2 for the specified target architecture.
+
+TARGET_HOST=$1
+INSTALL_PREFIX=$2
+
+if [ -z "$TARGET_HOST" ] || [ -z "$INSTALL_PREFIX" ]; then
+  echo "Usage: $0 <target-host> <install-prefix>"
+  echo "Example: $0 x86_64-w64-mingw32 /path/to/install"
+  exit 1
+fi
+
+SDL2_VERSION="2.30.5"
+echo "Building SDL2 from source for ${TARGET_HOST}..."
+
+curl -sL "https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/SDL2-${SDL2_VERSION}.tar.gz" | tar xz
+cd "SDL2-${SDL2_VERSION}"
+
+# Configure and build
+./configure \
+  --host=${TARGET_HOST} \
+  --prefix=${INSTALL_PREFIX} \
+  --enable-static \
+  --disable-shared \
+  --disable-video-x11
+
+make -j$(nproc)
+make install


### PR DESCRIPTION
Refactors the `.github/workflows/build-whisper-cpp.yml` workflow to address persistent build failures, particularly on Windows platforms.

The key changes are:
- Replaces the native Windows MSYS2 build environment with a more reliable cross-compilation setup using the `mstorsjo/llvm-mingw` Docker container on an Ubuntu runner.
- Consolidates the build logic into a single, unified `Build whisper.cpp` step that handles all target platforms (macOS, Linux, and Windows cross-compilation).
- Adds a helper script (`whisper.cpp/scripts/build-sdl2-mingw.sh`) to build the SDL2 dependency for Windows targets within the cross-compilation container.
- Includes the necessary CMake toolchain files for `x86_64` and `aarch64` Windows targets.
- Removes obsolete and complex build steps, significantly simplifying the workflow and improving maintainability.

This new approach provides a stable and consistent environment that resolves the various compiler and dependency errors encountered with the previous native Windows build setup.